### PR TITLE
Add newline parsing for symbol map name

### DIFF
--- a/src/kernel/heap.zig
+++ b/src/kernel/heap.zig
@@ -425,6 +425,8 @@ const FreeListAllocator = struct {
         testing.expectEqual(header.next_free, null);
         testing.expectEqual(free_list.first_free, header);
 
+        std.debug.warn("", .{});
+
         // 64 bytes aligned to 4 bytes
         const alloc1 = try alloc(allocator, 64, 4, 0);
         const alloc1_addr = @ptrToInt(alloc1.ptr);


### PR DESCRIPTION
The symbol name can have spaces.
Changed the parseName to use the newline parsing.
Also used str.len
Closes #199