### PR TITLE
Use vmm.virtToPhys in x86 paging instead of mem.virtToPhys

### DIFF
--- a/src/kernel/arch/x86/arch.zig
+++ b/src/kernel/arch/x86/arch.zig
@@ -360,6 +360,20 @@ pub fn initMem(mb_info: BootPayload) Allocator.Error!MemProfile {
         }
     }
 
+    // Map the kernel code
+    const kernel_virt = mem.Range{
+        .start = @ptrToInt(&KERNEL_VADDR_START),
+        .end = @ptrToInt(&KERNEL_STACK_START),
+    };
+    const kernel_phy = mem.Range{
+        .start = mem.virtToPhys(kernel_virt.start),
+        .end = mem.virtToPhys(kernel_virt.end),
+    };
+    try reserved_virtual_mem.append(.{
+        .virtual = kernel_virt,
+        .physical = kernel_phy,
+    });
+
     // Map the multiboot info struct itself
     const mb_region = mem.Range{
         .start = @ptrToInt(mb_info),
@@ -422,20 +436,6 @@ pub fn initMem(mb_info: BootPayload) Allocator.Error!MemProfile {
     try reserved_virtual_mem.append(.{
         .virtual = kernel_stack_virt,
         .physical = kernel_stack_phy,
-    });
-
-    // Map the rest of the kernel
-    const kernel_virt = mem.Range{
-        .start = @ptrToInt(&KERNEL_VADDR_START),
-        .end = @ptrToInt(&KERNEL_STACK_START),
-    };
-    const kernel_phy = mem.Range{
-        .start = mem.virtToPhys(kernel_virt.start),
-        .end = mem.virtToPhys(kernel_virt.end),
-    };
-    try reserved_virtual_mem.append(.{
-        .virtual = kernel_virt,
-        .physical = kernel_phy,
     });
 
     return MemProfile{

--- a/src/kernel/mem.zig
+++ b/src/kernel/mem.zig
@@ -42,10 +42,10 @@ pub const MemProfile = struct {
     /// The modules loaded into memory at boot.
     modules: []Module,
 
-    /// The virtual regions of reserved memory. Should not include what is tracked by the vaddr_* fields but should include the regions occupied by the modules. These are reserved and mapped by the VMM
+    /// The virtual regions of reserved memory. These are reserved and mapped by the VMM
     virtual_reserved: []Map,
 
-    /// The physical regions of reserved memory. Should not include what is tracked by the physaddr_* fields but should include the regions occupied by the modules. These are reserved by the PMM
+    /// The physical regions of reserved memory. These are reserved by the PMM
     physical_reserved: []Range,
 
     /// The allocator to use before a heap can be set up.

--- a/test/mock/kernel/mem_mock.zig
+++ b/test/mock/kernel/mem_mock.zig
@@ -29,12 +29,13 @@ pub const MemProfile = struct {
 };
 
 const FIXED_ALLOC_SIZE = 1024 * 1024;
+const ADDR_OFFSET: usize = 100;
 
 pub fn virtToPhys(virt: anytype) @TypeOf(virt) {
     const T = @TypeOf(virt);
     return switch (@typeInfo(T)) {
-        .Pointer => @intToPtr(T, @ptrToInt(virt) - KERNEL_ADDR_OFFSET),
-        .Int => virt - KERNEL_ADDR_OFFSET,
+        .Pointer => @intToPtr(T, @ptrToInt(virt) - ADDR_OFFSET),
+        .Int => virt - ADDR_OFFSET,
         else => @compileError("Only pointers and integers are supported"),
     };
 }
@@ -42,8 +43,8 @@ pub fn virtToPhys(virt: anytype) @TypeOf(virt) {
 pub fn physToVirt(phys: anytype) @TypeOf(phys) {
     const T = @TypeOf(phys);
     return switch (@typeInfo(T)) {
-        .Pointer => @intToPtr(T, @ptrToInt(phys) + KERNEL_ADDR_OFFSET),
-        .Int => phys + KERNEL_ADDR_OFFSET,
+        .Pointer => @intToPtr(T, @ptrToInt(phys) + ADDR_OFFSET),
+        .Int => phys + ADDR_OFFSET,
         else => @compileError("Only pointers and integers are supported"),
     };
 }

--- a/test/mock/kernel/vmm_mock.zig
+++ b/test/mock/kernel/vmm_mock.zig
@@ -1,5 +1,6 @@
 const mem = @import("mem_mock.zig");
 const bitmap = @import("../../../src/kernel/bitmap.zig");
+const vmm = @import("../../../src/kernel/vmm.zig");
 const arch = @import("arch_mock.zig");
 const std = @import("std");
 
@@ -8,20 +9,34 @@ pub const VmmError = error{
     NotAllocated,
 };
 
-pub const Attributes = struct {
-    kernel: bool,
-    writable: bool,
-    cachable: bool,
-};
+pub const Attributes = vmm.Attributes;
+
 pub const BLOCK_SIZE: u32 = 1024;
 
-pub fn Mapper(comptime Payload: type) type {
-    return struct {};
-}
+pub const Mapper = vmm.Mapper;
+
+pub const MapperError = error{
+    InvalidVirtualAddress,
+    InvalidPhysicalAddress,
+    AddressMismatch,
+    MisalignedVirtualAddress,
+    MisalignedPhysicalAddress,
+    NotMapped,
+};
+
+pub var kernel_vmm: VirtualMemoryManager(arch.VmmPayload) = undefined;
 
 pub fn VirtualMemoryManager(comptime Payload: type) type {
     return struct {
         const Self = @This();
+
+        pub fn init(start: usize, end: usize, allocator: *std.mem.Allocator, mapper: Mapper(Payload), payload: Payload) std.mem.Allocator.Error!Self {
+            return Self{};
+        }
+
+        pub fn virtToPhys(self: *const Self, virt: usize) VmmError!usize {
+            return 0;
+        }
 
         pub fn alloc(self: *Self, num: u32, attrs: Attributes) std.mem.Allocator.Error!?usize {
             return std.mem.Allocator.Error.OutOfMemory;


### PR DESCRIPTION
This patch makes x86 paging use `vmm.virtToPhys` rather than mem.virtToPhys to close #226.

It also stores declares `kernel_vmm` in `vmm.zig` rather than `kmain.zig` so that it is more accessible.
