### PR TITLE
Add user mode

### DIFF
--- a/src/kernel/arch/x86/gdt.zig
+++ b/src/kernel/arch/x86/gdt.zig
@@ -358,7 +358,7 @@ var gdt_ptr: GdtPtr = GdtPtr{
 };
 
 /// The main task state segment entry.
-var main_tss_entry: Tss = init: {
+pub var main_tss_entry: Tss = init: {
     var tss_temp = std.mem.zeroes(Tss);
     tss_temp.ss0 = KERNEL_DATA_OFFSET;
     tss_temp.io_permissions_base_offset = @sizeOf(Tss);

--- a/src/kernel/arch/x86/interrupts.zig
+++ b/src/kernel/arch/x86/interrupts.zig
@@ -32,7 +32,8 @@ export fn commonStub() callconv(.Naked) void {
         \\push  %%es
         \\push  %%fs
         \\push  %%gs
-        \\push  %%ss
+        \\mov %%cr3, %%eax
+        \\push %%eax
         \\mov   $0x10, %%ax
         \\mov   %%ax, %%ds
         \\mov   %%ax, %%es
@@ -42,13 +43,30 @@ export fn commonStub() callconv(.Naked) void {
         \\push  %%eax
         \\call  handler
         \\mov   %%eax, %%esp
-        \\pop   %%ss
+    );
+
+    // Pop off the new cr3 then check if it's the same as the previous cr3
+    // If so don't change cr3 to avoid a TLB flush
+    asm volatile (
+        \\pop   %%eax
+        \\mov   %%cr3, %%ebx
+        \\cmp   %%eax, %%ebx
+        \\je    same_cr3
+        \\mov   %%eax, %%cr3
+        \\same_cr3:
         \\pop   %%gs
         \\pop   %%fs
         \\pop   %%es
         \\pop   %%ds
         \\popa
-        \\add   $0x8, %%esp
+    );
+    // The Tss.esp0 value is the stack pointer used when an interrupt occurs. This should be the current process' stack pointer
+    // So skip the rest of the CpuState, set Tss.esp0 then un-skip the last few fields of the CpuState
+    asm volatile (
+        \\add   $0x1C, %%esp
+        \\.extern main_tss_entry
+        \\mov   %%esp, (main_tss_entry + 4)
+        \\sub   $0x14, %%esp
         \\iret
     );
 }

--- a/src/kernel/bitmap.zig
+++ b/src/kernel/bitmap.zig
@@ -240,6 +240,29 @@ pub fn Bitmap(comptime BitmapType: type) type {
         }
 
         ///
+        /// Clone this bitmap.
+        ///
+        /// Arguments:
+        ///     IN self: *Self - The bitmap to clone.
+        ///
+        /// Return: Self
+        ///     The cloned bitmap
+        ///
+        /// Error: std.mem.Allocator.Error
+        ///     OutOfMemory: There isn't enough memory available to allocate the required number of BitmapType.
+        ///
+        pub fn clone(self: *const Self) std.mem.Allocator.Error!Self {
+            var copy = try init(self.num_entries, self.allocator);
+            var i: usize = 0;
+            while (i < copy.num_entries) : (i += 1) {
+                if (self.isSet(i) catch unreachable) {
+                    copy.setEntry(i) catch unreachable;
+                }
+            }
+            return copy;
+        }
+
+        ///
         /// Free the memory occupied by this bitmap's internal state. It will become unusable afterwards.
         ///
         /// Arguments:

--- a/src/kernel/filesystem/vfs.zig
+++ b/src/kernel/filesystem/vfs.zig
@@ -753,7 +753,6 @@ test "traversePath" {
     testing.expectEqual(child4_linked, child3);
     var child5 = try traversePath("/child4", false, .CREATE_SYMLINK, .{ .symlink_target = "/child2" });
     var child5_linked = try traversePath("/child4/child3.txt", true, .NO_CREATION, .{});
-    std.debug.warn("child5_linked {}, child4_linked {}\n", .{ child5_linked, child4_linked });
     testing.expectEqual(child5_linked, child4_linked);
     child4_linked.File.close();
     child5_linked.File.close();

--- a/src/kernel/task.zig
+++ b/src/kernel/task.zig
@@ -8,6 +8,7 @@ const mock_path = build_options.mock_path;
 const arch = @import("arch.zig").internals;
 const panic = if (is_test) @import(mock_path ++ "panic_mock.zig").panic else @import("panic.zig").panic;
 const ComptimeBitmap = @import("bitmap.zig").ComptimeBitmap;
+const vmm = @import("vmm.zig");
 const Allocator = std.mem.Allocator;
 
 /// The kernels main stack start as this is used to check for if the task being destroyed is this stack
@@ -15,7 +16,7 @@ const Allocator = std.mem.Allocator;
 extern var KERNEL_STACK_START: *u32;
 
 /// The function type for the entry point.
-const EntryPointFn = fn () void;
+pub const EntryPoint = usize;
 
 /// The bitmap type for the PIDs
 const PidBitmap = if (is_test) ComptimeBitmap(u128) else ComptimeBitmap(u1024);
@@ -28,6 +29,9 @@ var all_pids: PidBitmap = brk: {
     break :brk pids;
 };
 
+/// The default stack size of a task. Currently this is set to a page size.
+pub const STACK_SIZE: u32 = arch.MEMORY_BLOCK_SIZE / @sizeOf(u32);
+
 /// The task control block for storing all the information needed to save and restore a task.
 pub const Task = struct {
     const Self = @This();
@@ -35,11 +39,20 @@ pub const Task = struct {
     /// The unique task identifier
     pid: PidBitmap.IndexType,
 
-    /// Pointer to the stack for the task. This will be allocated on initialisation.
-    stack: []u32,
+    /// Pointer to the kernel stack for the task. This will be allocated on initialisation.
+    kernel_stack: []usize,
+
+    /// Pointer to the user stack for the task. This will be allocated on initialisation and will be empty if it's a kernel task
+    user_stack: []usize,
 
     /// The current stack pointer into the stack.
     stack_pointer: usize,
+
+    /// Whether the process is a kernel process or not
+    kernel: bool,
+
+    /// The virtual memory manager belonging to the task
+    vmm: *vmm.VirtualMemoryManager(arch.VmmPayload),
 
     ///
     /// Create a task. This will allocate a PID and the stack. The stack will be set up as a
@@ -47,7 +60,9 @@ pub const Task = struct {
     /// state as described in arch.CpuState struct.
     ///
     /// Arguments:
-    ///     IN entry_point: EntryPointFn - The entry point into the task. This must be a function.
+    ///     IN entry_point: EntryPoint - The entry point into the task. This must be a function.
+    ///     IN kernel: bool              - Whether the task has kernel or user privileges.
+    ///     IN task_vmm: *VirtualMemoryManager - The virtual memory manager associated with the task.
     ///     IN allocator: *Allocator     - The allocator for allocating memory for a task.
     ///
     /// Return: *Task
@@ -57,16 +72,29 @@ pub const Task = struct {
     ///     OutOfMemory - If there is no more memory to allocate. Any memory or PID allocated will
     ///                   be freed on return.
     ///
-    pub fn create(entry_point: EntryPointFn, allocator: *Allocator) Allocator.Error!*Task {
+    pub fn create(entry_point: EntryPoint, kernel: bool, task_vmm: *vmm.VirtualMemoryManager(arch.VmmPayload), allocator: *Allocator) Allocator.Error!*Task {
         var task = try allocator.create(Task);
         errdefer allocator.destroy(task);
 
-        task.pid = allocatePid();
-        errdefer freePid(task.pid);
+        const pid = allocatePid();
+        errdefer freePid(pid);
 
-        const task_stack = try arch.initTaskStack(@ptrToInt(entry_point), allocator);
-        task.stack = task_stack.stack;
-        task.stack_pointer = task_stack.pointer;
+        var k_stack = try allocator.alloc(usize, STACK_SIZE);
+        errdefer allocator.free(k_stack);
+
+        var u_stack = if (kernel) &[_]usize{} else try allocator.alloc(usize, STACK_SIZE);
+        errdefer if (!kernel) allocator.free(u_stack);
+
+        task.* = .{
+            .pid = pid,
+            .kernel_stack = k_stack,
+            .user_stack = u_stack,
+            .stack_pointer = @ptrToInt(&k_stack[STACK_SIZE - 1]),
+            .kernel = kernel,
+            .vmm = task_vmm,
+        };
+
+        try arch.initTask(task, entry_point, allocator);
 
         return task;
     }
@@ -81,8 +109,11 @@ pub const Task = struct {
         freePid(self.pid);
         // We need to check that the the stack has been allocated as task 0 (init) won't have a
         // stack allocated as this in the linker script
-        if (@ptrToInt(self.stack.ptr) != @ptrToInt(&KERNEL_STACK_START)) {
-            allocator.free(self.stack);
+        if (@ptrToInt(self.kernel_stack.ptr) != @ptrToInt(&KERNEL_STACK_START)) {
+            allocator.free(self.kernel_stack);
+        }
+        if (!self.kernel) {
+            allocator.free(self.user_stack);
         }
         allocator.destroy(self);
     }
@@ -122,7 +153,8 @@ test "create out of memory for task" {
     // Set the global allocator
     var fa = FailingAllocator.init(testing_allocator, 0);
 
-    expectError(error.OutOfMemory, Task.create(test_fn1, &fa.allocator));
+    expectError(error.OutOfMemory, Task.create(@ptrToInt(test_fn1), true, undefined, &fa.allocator));
+    expectError(error.OutOfMemory, Task.create(@ptrToInt(test_fn1), false, undefined, &fa.allocator));
 
     // Make sure any memory allocated is freed
     expectEqual(fa.allocated_bytes, fa.freed_bytes);
@@ -135,7 +167,8 @@ test "create out of memory for stack" {
     // Set the global allocator
     var fa = FailingAllocator.init(testing_allocator, 1);
 
-    expectError(error.OutOfMemory, Task.create(test_fn1, &fa.allocator));
+    expectError(error.OutOfMemory, Task.create(@ptrToInt(test_fn1), true, undefined, &fa.allocator));
+    expectError(error.OutOfMemory, Task.create(@ptrToInt(test_fn1), false, undefined, &fa.allocator));
 
     // Make sure any memory allocated is freed
     expectEqual(fa.allocated_bytes, fa.freed_bytes);
@@ -145,32 +178,39 @@ test "create out of memory for stack" {
 }
 
 test "create expected setup" {
-    var task = try Task.create(test_fn1, std.testing.allocator);
+    var task = try Task.create(@ptrToInt(test_fn1), true, undefined, std.testing.allocator);
     defer task.destroy(std.testing.allocator);
 
     // Will allocate the first PID 1, 0 will always be allocated
     expectEqual(task.pid, 1);
+    expectEqual(task.kernel_stack.len, STACK_SIZE);
+    expectEqual(task.user_stack.len, 0);
+
+    var user_task = try Task.create(@ptrToInt(test_fn1), false, undefined, std.testing.allocator);
+    defer user_task.destroy(std.testing.allocator);
+    expectEqual(user_task.pid, 2);
+    expectEqual(user_task.user_stack.len, STACK_SIZE);
+    expectEqual(user_task.kernel_stack.len, STACK_SIZE);
 }
 
 test "destroy cleans up" {
     // This used the leak detector allocator in testing
     // So if any alloc were not freed, this will fail the test
-    var fa = FailingAllocator.init(testing_allocator, 2);
+    var allocator = std.testing.allocator;
 
-    var task = try Task.create(test_fn1, &fa.allocator);
+    var task = try Task.create(@ptrToInt(test_fn1), true, undefined, allocator);
+    var user_task = try Task.create(@ptrToInt(test_fn1), false, undefined, allocator);
 
-    task.destroy(&fa.allocator);
-
-    // Make sure any memory allocated is freed
-    expectEqual(fa.allocated_bytes, fa.freed_bytes);
+    task.destroy(allocator);
+    user_task.destroy(allocator);
 
     // All PIDs were freed
     expectEqual(all_pids.bitmap, 1);
 }
 
 test "Multiple create" {
-    var task1 = try Task.create(test_fn1, std.testing.allocator);
-    var task2 = try Task.create(test_fn1, std.testing.allocator);
+    var task1 = try Task.create(@ptrToInt(test_fn1), true, undefined, std.testing.allocator);
+    var task2 = try Task.create(@ptrToInt(test_fn1), true, undefined, std.testing.allocator);
 
     expectEqual(task1.pid, 1);
     expectEqual(task2.pid, 2);
@@ -180,13 +220,21 @@ test "Multiple create" {
 
     expectEqual(all_pids.bitmap, 5);
 
-    var task3 = try Task.create(test_fn1, std.testing.allocator);
+    var task3 = try Task.create(@ptrToInt(test_fn1), true, undefined, std.testing.allocator);
 
     expectEqual(task3.pid, 1);
     expectEqual(all_pids.bitmap, 7);
 
     task2.destroy(std.testing.allocator);
     task3.destroy(std.testing.allocator);
+
+    var user_task = try Task.create(@ptrToInt(test_fn1), false, undefined, std.testing.allocator);
+
+    expectEqual(user_task.pid, 1);
+    expectEqual(all_pids.bitmap, 3);
+
+    user_task.destroy(std.testing.allocator);
+    expectEqual(all_pids.bitmap, 1);
 }
 
 test "allocatePid and freePid" {

--- a/test/gen_types.zig
+++ b/test/gen_types.zig
@@ -49,6 +49,7 @@ const types = .{
     .{ "*const IdtPtr", "PTR_CONST_IDTPTR", "idt_mock", "", "IdtPtr" },
     .{ "*Task", "PTR_TASK", "task_mock", "", "Task" },
     .{ "*Allocator", "PTR_ALLOCATOR", "", "std.mem", "Allocator" },
+    .{ "*VirtualMemoryManager(u8)", "PTR_VMM", "vmm_mock", "", "VirtualMemoryManager" },
 
     .{ "IdtError!void", "ERROR_IDTERROR_RET_VOID", "idt_mock", "", "IdtError" },
     .{ "Allocator.Error!*Task", "ERROR_ALLOCATOR_RET_PTRTASK", "", "", "" },
@@ -82,6 +83,7 @@ const types = .{
     .{ "fn (*Task, usize) void", "FN_IPTRTASK_IUSIZE_OVOID", "", "", "" },
     .{ "fn (*Task, *Allocator) void", "FN_IPTRTASK_IPTRALLOCATOR_OVOID", "", "", "" },
     .{ "fn (fn () void, *Allocator) Allocator.Error!*Task", "FN_IFNOVOID_IPTRALLOCATOR_EALLOCATOR_OPTRTASK", "", "", "" },
+    .{ "fn (usize, *Allocator, bool, *VirtualMemoryManager(u8)) Allocator.Error!*Task", "FN_IUSIZE_IPTRALLOCATOR_IBOOL_IVMM_EALLOCATOR_OVOID", "", "", "" },
 
     .{ "fn (StatusRegister, u8, bool) void", "FN_ISTATUSREGISTER_IU8_IBOOL_OVOID", "", "", "" },
 };

--- a/test/mock/kernel/arch_mock.zig
+++ b/test/mock/kernel/arch_mock.zig
@@ -11,7 +11,7 @@ const Serial = @import("../../../src/kernel/serial.zig").Serial;
 const TTY = @import("../../../src/kernel/tty.zig").TTY;
 const Keyboard = @import("../../../src/kernel/keyboard.zig").Keyboard;
 
-pub const task = @import("task_mock.zig");
+pub const task = @import("../../../src/kernel/task.zig");
 
 pub const Device = pci.PciDeviceInfo;
 
@@ -141,10 +141,7 @@ pub fn initMem(payload: BootPayload) Allocator.Error!mem.MemProfile {
     };
 }
 
-pub fn initTaskStack(entry_point: usize, allocator: *Allocator) Allocator.Error!struct { stack: []u32, pointer: usize } {
-    const ret = .{ .stack = &([_]u32{}), .pointer = 0 };
-    return ret;
-}
+pub fn initTask(t: *Task, entry_point: usize, allocator: *Allocator) Allocator.Error!void {}
 
 pub fn initKeyboard(allocator: *Allocator) Allocator.Error!?*Keyboard {
     return null;

--- a/test/mock/kernel/mock_framework_template.zig
+++ b/test/mock/kernel/mock_framework_template.zig
@@ -146,6 +146,7 @@ fn Mock() type {
                 1 => fn (fields[0].field_type) RetType,
                 2 => fn (fields[0].field_type, fields[1].field_type) RetType,
                 3 => fn (fields[0].field_type, fields[1].field_type, fields[2].field_type) RetType,
+                4 => fn (fields[0].field_type, fields[1].field_type, fields[2].field_type, fields[3].field_type) RetType,
                 else => @compileError("More than 3 parameters not supported"),
             };
         }
@@ -167,6 +168,7 @@ fn Mock() type {
                 1 => function_type(params[0]),
                 2 => function_type(params[0], params[1]),
                 3 => function_type(params[0], params[1], params[2]),
+                4 => function_type(params[0], params[1], params[2], params[3]),
                 // Should get to this as `getFunctionType` will catch this
                 else => @compileError("More than 3 parameters not supported"),
             };

--- a/test/mock/kernel/task_mock.zig
+++ b/test/mock/kernel/task_mock.zig
@@ -1,4 +1,6 @@
 const std = @import("std");
+const vmm = @import("vmm_mock.zig");
+const arch = @import("arch_mock.zig");
 const Allocator = std.mem.Allocator;
 
 const mock_framework = @import("mock_framework.zig");
@@ -8,17 +10,20 @@ pub const addTestParams = mock_framework.addTestParams;
 pub const addConsumeFunction = mock_framework.addConsumeFunction;
 pub const addRepeatFunction = mock_framework.addRepeatFunction;
 
-const EntryPointFn = fn () void;
+pub const EntryPoint = usize;
 
 pub const Task = struct {
     const Self = @This();
 
     pid: u32,
-    stack: []u32,
+    kernel_stack: []u32,
+    user_stack: []u32,
     stack_pointer: usize,
+    kernel: bool,
+    vmm: vmm.VirtualMemoryManager(arch.VmmPayload),
 
-    pub fn create(entry_point: EntryPointFn, allocator: *Allocator) Allocator.Error!*Task {
-        return mock_framework.performAction("Task.create", Allocator.Error!*Task, .{ entry_point, allocator });
+    pub fn create(entry_point: EntryPoint, kernel: bool, task_vmm: *vmm.VirtualMemoryManager(arch.VmmPayload), allocator: *Allocator) Allocator.Error!*Task {
+        return mock_framework.performAction("Task.create", Allocator.Error!*Task, .{ entry_point, allocator, kernel, task_vmm });
     }
 
     pub fn destroy(self: *Self, allocator: *Allocator) void {

--- a/test/mock/kernel/vmm_mock.zig
+++ b/test/mock/kernel/vmm_mock.zig
@@ -3,6 +3,7 @@ const bitmap = @import("../../../src/kernel/bitmap.zig");
 const vmm = @import("../../../src/kernel/vmm.zig");
 const arch = @import("arch_mock.zig");
 const std = @import("std");
+const Allocator = std.mem.Allocator;
 
 pub const VmmError = error{
     /// A memory region expected to be allocated wasn't
@@ -45,9 +46,11 @@ pub fn VirtualMemoryManager(comptime Payload: type) type {
         pub fn free(self: *Self, vaddr: usize) (bitmap.Bitmap(u32).BitmapError || VmmError)!void {
             return VmmError.NotAllocated;
         }
+
+        pub fn copyDataToVMM(self: *Self, to: *const Self, data: []const u8, dest: usize) (bitmap.Bitmap(usize).BitmapError || VmmError || Allocator.Error)!void {}
     };
 }
 
-pub fn init(mem_profile: *const mem.MemProfile, allocator: *std.mem.Allocator) std.mem.Allocator.Error!VirtualMemoryManager(arch.VmmPayload) {
+pub fn init(mem_profile: *const mem.MemProfile, allocator: *Allocator) Allocator.Error!*VirtualMemoryManager(arch.VmmPayload) {
     return std.mem.Allocator.Error.OutOfMemory;
 }

--- a/test/user_program.s
+++ b/test/user_program.s
@@ -1,0 +1,6 @@
+entry:
+    mov $0xCAFE, %eax
+    mov $0xBEEF, %ebx
+loop:
+    jmp loop
+


### PR DESCRIPTION
This patch adds user mode for tasks. Each user task is given its own VMM and its code is copied from kernel memory into its address space. This patch also stops deinitialisation of the initrd so that testing files can be loaded (I think deinitialisation should be done just before setting the root to the hard disk, once that is implemented).

I still have some tests and doc comments to add but the implementation can be reviewed in its current state.

Closes #50 