### PR TITLE
Minor change: reorder destroy() and deinit()

### DIFF
--- a/src/kernel/filesystem/vfs.zig
+++ b/src/kernel/filesystem/vfs.zig
@@ -591,8 +591,8 @@ test "mount" {
 
     // The fs that is to be mounted
     var testfs2 = try testInitFs(allocator);
-    defer testfs2.deinit();
     defer allocator.destroy(testfs2);
+    defer testfs2.deinit();
 
     testfs2.instance = 2;
     // Create the dir to mount to


### PR DESCRIPTION
Seems to solve https://github.com/ZystemOS/pluto/issues/231