### PR TITLE
Assert valid aarch64 exception levels

### DIFF
--- a/src/kernel/arch/aarch64/tty.zig
+++ b/src/kernel/arch/aarch64/tty.zig
@@ -171,7 +171,7 @@ pub fn setCursor(x: u8, y: u8) void {
 ///
 /// Return: TTY
 ///     The TTY struct that is used to work with the frame buffer
-///     
+///
 ///
 pub fn init(allocator: *std.mem.Allocator, board: arch.BootPayload) TTY {
     var fb_addr: u32 = undefined;


### PR DESCRIPTION
System registers that are separated by exception level are only available in certain exception levels. This change asserts that only the correct levels are used.
@SamTebbs33 