### PR TITLE
Check for memory leaks in all tests that allocate memory

### DIFF
--- a/src/kernel/filesystem/initrd.zig
+++ b/src/kernel/filesystem/initrd.zig
@@ -336,18 +336,13 @@ const init_allocations: usize = 10;
 test "init with files cleans memory if OutOfMemory" {
     var i: usize = 0;
     while (i < init_allocations) : (i += 1) {
-        {
-            var fa = std.testing.FailingAllocator.init(std.testing.allocator, i);
+        var fa = std.testing.FailingAllocator.init(std.testing.allocator, i);
 
-            var ramdisk_bytes = try createInitrd(std.testing.allocator);
-            defer std.testing.allocator.free(ramdisk_bytes);
+        var ramdisk_bytes = try createInitrd(std.testing.allocator);
+        defer std.testing.allocator.free(ramdisk_bytes);
 
-            var initrd_stream = std.io.fixedBufferStream(ramdisk_bytes);
-            expectError(error.OutOfMemory, InitrdFS.init(&initrd_stream, &fa.allocator));
-        }
-
-        // Ensure we have freed any memory allocated
-        std.testing.expectEqual(false, std.testing.allocator_instance.detectLeaks());
+        var initrd_stream = std.io.fixedBufferStream(ramdisk_bytes);
+        expectError(error.OutOfMemory, InitrdFS.init(&initrd_stream, &fa.allocator));
     }
 }
 

--- a/src/kernel/panic.zig
+++ b/src/kernel/panic.zig
@@ -484,8 +484,9 @@ test "parseMapEntry fails without a name" {
 }
 
 test "SymbolMap" {
-    var allocator = std.heap.page_allocator;
+    var allocator = std.testing.allocator;
     var map = SymbolMap.init(allocator);
+    defer map.deinit();
     try map.add("abc"[0..], 123);
     try map.addEntry(MapEntry{ .func_name = "def"[0..], .addr = 456 });
     try map.add("ghi"[0..], 789);

--- a/src/kernel/pmm.zig
+++ b/src/kernel/pmm.zig
@@ -129,8 +129,16 @@ pub fn init(mem_profile: *const MemProfile, allocator: *Allocator) void {
     }
 }
 
+///
+/// Free the internal state of the PMM. Is unusable aftwards unless re-initialised
+///
+pub fn deinit() void {
+    bitmap.deinit();
+}
+
 test "alloc" {
-    bitmap = try Bitmap(u32).init(32, std.heap.page_allocator);
+    bitmap = try Bitmap(u32).init(32, testing.allocator);
+    defer bitmap.deinit();
     comptime var addr = 0;
     comptime var i = 0;
     // Allocate all entries, making sure they succeed and return the correct addresses
@@ -148,7 +156,8 @@ test "alloc" {
 }
 
 test "free" {
-    bitmap = try Bitmap(u32).init(32, std.heap.page_allocator);
+    bitmap = try Bitmap(u32).init(32, testing.allocator);
+    defer bitmap.deinit();
     comptime var i = 0;
     // Allocate and free all entries
     inline while (i < 32) : (i += 1) {
@@ -165,7 +174,8 @@ test "free" {
 
 test "setAddr and isSet" {
     const num_entries: u32 = 32;
-    bitmap = try Bitmap(u32).init(num_entries, std.heap.page_allocator);
+    bitmap = try Bitmap(u32).init(num_entries, testing.allocator);
+    defer bitmap.deinit();
     var addr: u32 = 0;
     var i: u32 = 0;
     while (i < num_entries) : ({

--- a/test/mock/kernel/mem_mock.zig
+++ b/test/mock/kernel/mem_mock.zig
@@ -28,6 +28,8 @@ pub const MemProfile = struct {
     fixed_allocator: std.heap.FixedBufferAllocator,
 };
 
+pub var fixed_buffer_allocator: std.heap.FixedBufferAllocator = undefined;
+
 const FIXED_ALLOC_SIZE = 1024 * 1024;
 const ADDR_OFFSET: usize = 100;
 


### PR DESCRIPTION
This standardises the allocator used in tests and adds leak detection to each that allocates memory. Deinitialisation functions have been added when missing. Closes #223﻿
