### PR TITLE
Rework copyDataToVMM to work in both directions

### DIFF
--- a/src/kernel/scheduler.zig
+++ b/src/kernel/scheduler.zig
@@ -394,7 +394,7 @@ fn rt_user_task(allocator: *Allocator, mem_profile: *const mem.MemProfile) void 
     } orelse panic(null, "User task VMM didn't allocate space for the user program\n", .{});
     if (code_start != 0) panic(null, "User program start address was {} instead of 0\n", .{code_start});
     // 5. Copy user_program code over
-    vmm.kernel_vmm.copyDataToVMM(task_vmm, code[0..code_len], code_start) catch |e| {
+    vmm.kernel_vmm.copyData(task_vmm, code[0..code_len], code_start, true) catch |e| {
         panic(@errorReturnTrace(), "Failed to copy user code: {}\n", .{e});
     };
     // 6. Schedule it

--- a/test/mock/kernel/vmm_mock.zig
+++ b/test/mock/kernel/vmm_mock.zig
@@ -47,7 +47,7 @@ pub fn VirtualMemoryManager(comptime Payload: type) type {
             return VmmError.NotAllocated;
         }
 
-        pub fn copyDataToVMM(self: *Self, to: *const Self, data: []const u8, dest: usize) (bitmap.Bitmap(usize).BitmapError || VmmError || Allocator.Error)!void {}
+        pub fn copyData(self: *Self, other: *Self, data: []const u8, dest: usize, from_self: bool) (bitmap.Bitmap(usize).BitmapError || VmmError || Allocator.Error)!void {}
     };
 }
 


### PR DESCRIPTION
This patch reworks vmm.copyDataToVMM to allow it to either copy to or from another VMM. This new capability will be used in syscalls when copying data from user memory to kernel memory.﻿
