### PR TITLE
Feature/fat32 open

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -217,7 +217,7 @@ const Fat32BuilderStep = struct {
         // If there was an error, delete the image as this will be invalid
         errdefer (std.fs.cwd().deleteFile(self.out_file_path) catch unreachable);
         defer image.close();
-        try Fat32.make(self.options, image);
+        try Fat32.make(self.options, image, false);
     }
 
     ///

--- a/src/kernel/filesystem/vfs.zig
+++ b/src/kernel/filesystem/vfs.zig
@@ -245,6 +245,9 @@ pub const Error = error{
 
     /// No symlink target was provided when one was expected
     NoSymlinkTarget,
+
+    /// An unexpected error ocurred when performing a VFS operation.
+    Unexpected,
 };
 
 /// Errors that can be thrown when attempting to mount


### PR DESCRIPTION
Needed to return a pointer to the file system as `@fieldParentPtr(Fat32Self, "instance", fs.instance)` doesn't work as the the pointer to `instance` is on the stack, then goes out of scope when the init is returned. So will be using free stack space.
Part of #216