### PR TITLE
Update to zig master

### DIFF
--- a/src/kernel/kmain.zig
+++ b/src/kernel/kmain.zig
@@ -44,7 +44,7 @@ export var KERNEL_PHYSADDR_END: u32 = if (builtin.is_test) 0x14E000 else undefin
 // Just call the panic function, as this need to be in the root source file
 pub fn panic(msg: []const u8, error_return_trace: ?*builtin.StackTrace) noreturn {
     @setCold(true);
-    panic_root.panic(error_return_trace, "{}", .{msg});
+    panic_root.panic(error_return_trace, "{s}", .{msg});
 }
 
 pub const log_level: std.log.Level = .debug;
@@ -173,7 +173,7 @@ fn initStage2() noreturn {
         \\                 | |      | |____  | |__| |    | |    | |__| |
         \\                 |_|      |______|  \____/     |_|     \____/
     ;
-    tty.print("{}\n\n", .{logo});
+    tty.print("{s}\n\n", .{logo});
 
     tty.print("Hello Pluto from kernel :)\n", .{});
 

--- a/src/kernel/log.zig
+++ b/src/kernel/log.zig
@@ -7,8 +7,8 @@ const scheduler = @import("scheduler.zig");
 /// The errors that can occur when logging
 const LoggingError = error{};
 
-/// The OutStream for the format function
-const OutStream = std.io.OutStream(void, LoggingError, logCallback);
+/// The Writer for the format function
+const Writer = std.io.Writer(void, LoggingError, logCallback);
 
 /// The serial object where the logs will be written to. This will be a COM serial port.
 var serial: Serial = undefined;
@@ -44,7 +44,7 @@ fn logCallback(context: void, str: []const u8) LoggingError!usize {
 ///
 pub fn log(comptime level: std.log.Level, comptime format: []const u8, args: anytype) void {
     scheduler.taskSwitching(false);
-    fmt.format(OutStream{ .context = {} }, "[" ++ @tagName(level) ++ "] " ++ format, args) catch unreachable;
+    fmt.format(Writer{ .context = {} }, "[" ++ @tagName(level) ++ "] " ++ format, args) catch unreachable;
     scheduler.taskSwitching(true);
 }
 
@@ -70,6 +70,6 @@ fn runtimeTests() void {
     inline for (@typeInfo(std.log.Level).Enum.fields) |field| {
         const level = @field(std.log.Level, field.name);
         log(level, "Test " ++ field.name ++ " level\n", .{});
-        log(level, "Test " ++ field.name ++ " level with args {}, {}\n", .{ "a", @as(u32, 1) });
+        log(level, "Test " ++ field.name ++ " level with args {s}, {}\n", .{ "a", @as(u32, 1) });
     }
 }

--- a/src/kernel/panic.zig
+++ b/src/kernel/panic.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const builtin = @import("builtin");
-const tty = @import("tty.zig");
 const arch = @import("arch.zig").internals;
 const multiboot = @import("multiboot.zig");
 const mem = @import("mem.zig");
@@ -112,7 +111,7 @@ var symbol_map: ?SymbolMap = null;
 ///
 fn logTraceAddress(addr: usize) void {
     const str = if (symbol_map) |syms| syms.search(addr) orelse "?????" else "(no symbols available)";
-    log.emerg("{x}: {}\n", .{ addr, str });
+    log.emerg("{x}: {s}\n", .{ addr, str });
 }
 
 ///

--- a/src/kernel/tty.zig
+++ b/src/kernel/tty.zig
@@ -7,7 +7,7 @@ const arch = @import("arch.zig").internals;
 const panic = @import("panic.zig").panic;
 
 /// The OutStream for the format function
-const OutStream = std.io.OutStream(void, anyerror, printCallback);
+const Writer = std.io.Writer(void, anyerror, printCallback);
 
 pub const TTY = struct {
     /// Print a already-formatted string
@@ -51,7 +51,7 @@ fn printCallback(ctx: void, str: []const u8) !usize {
 ///
 pub fn print(comptime format: []const u8, args: anytype) void {
     // Printing can't error because of the scrolling, if it does, we have a big problem
-    fmt.format(OutStream{ .context = {} }, format, args) catch |e| {
+    fmt.format(Writer{ .context = {} }, format, args) catch |e| {
         log.emerg("Error printing. Error: {}\n", .{e});
     };
 }

--- a/test/runtime_test.zig
+++ b/test/runtime_test.zig
@@ -99,7 +99,7 @@ pub const RuntimeStep = struct {
         while (true) {
             const msg = self.get_msg() catch return true;
             defer self.builder.allocator.free(msg);
-            std.debug.warn("{}\n", .{msg});
+            std.debug.warn("{s}\n", .{msg});
         }
     }
 
@@ -117,7 +117,7 @@ pub const RuntimeStep = struct {
             const msg = self.get_msg() catch return false;
             defer self.builder.allocator.free(msg);
             // Print the line to see what is going on
-            std.debug.warn("{}\n", .{msg});
+            std.debug.warn("{s}\n", .{msg});
             if (std.mem.indexOf(u8, msg, "FAILURE")) |_| {
                 return false;
             } else if (std.mem.indexOf(u8, msg, "Kernel panic")) |_| {
@@ -142,7 +142,7 @@ pub const RuntimeStep = struct {
             const msg = self.get_msg() catch return false;
             defer self.builder.allocator.free(msg);
             // Print the line to see what is going on
-            std.debug.warn("{}\n", .{msg});
+            std.debug.warn("{s}\n", .{msg});
             if (std.mem.eql(u8, msg, "[emerg] (panic): Kernel panic: integer overflow")) {
                 return true;
             }
@@ -164,7 +164,7 @@ pub const RuntimeStep = struct {
             const msg = self.get_msg() catch return false;
             defer self.builder.allocator.free(msg);
 
-            std.debug.warn("{}\n", .{msg});
+            std.debug.warn("{s}\n", .{msg});
 
             // Make sure `[INFO] Switched` then `[INFO] SUCCESS: Scheduler variables preserved` are logged in this order
             if (std.mem.eql(u8, msg, "[info] (scheduler): Switched") and state == 0) {


### PR DESCRIPTION
This PR renames uses of `OutStream` to `Writer`. `OutStream` and `InStream` were deprecated last release and have recently been removed entirely in favour of `Writer` and `Reader`.﻿
