### PR TITLE
Remove constants.zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -38,7 +38,6 @@ pub fn build(b: *Builder) !void {
 
     const main_src = "src/kernel/kmain.zig";
     const arch_root = "src/kernel/arch";
-    const constants_path = try fs.path.join(b.allocator, &[_][]const u8{ arch_root, arch, "constants.zig" });
     const linker_script_path = try fs.path.join(b.allocator, &[_][]const u8{ arch_root, arch, "link.ld" });
     const output_iso = try fs.path.join(b.allocator, &[_][]const u8{ b.exe_dir, "pluto.iso" });
     const iso_dir_path = try fs.path.join(b.allocator, &[_][]const u8{ b.exe_dir, "iso" });
@@ -60,7 +59,6 @@ pub fn build(b: *Builder) !void {
     const disable_display = b.option(bool, "disable-display", "Disable the qemu window") orelse false;
 
     const exec = b.addExecutable("pluto.elf", main_src);
-    exec.addPackagePath("constants", constants_path);
     exec.setOutputDir(b.cache_root);
     exec.addBuildOption(TestMode, "test_mode", test_mode);
     exec.setBuildMode(build_mode);
@@ -108,7 +106,6 @@ pub fn build(b: *Builder) !void {
     const unit_tests = b.addTest(main_src);
     unit_tests.setBuildMode(build_mode);
     unit_tests.setMainPkgPath(".");
-    unit_tests.addPackagePath("constants", constants_path);
     unit_tests.addBuildOption(TestMode, "test_mode", test_mode);
     unit_tests.addBuildOption([]const u8, "mock_path", mock_path);
     unit_tests.addBuildOption([]const u8, "arch_mock_path", arch_mock_path);

--- a/src/kernel/arch/x86/boot.zig
+++ b/src/kernel/arch/x86/boot.zig
@@ -1,4 +1,3 @@
-const constants = @import("constants");
 const arch = @import("arch.zig");
 
 /// The multiboot header
@@ -13,7 +12,7 @@ const MEMINFO = 1 << 1;
 const MAGIC = 0x1BADB002;
 const FLAGS = ALIGN | MEMINFO;
 
-const KERNEL_PAGE_NUMBER = constants.KERNEL_ADDR_OFFSET >> 22;
+const KERNEL_PAGE_NUMBER = 0xC0000000 >> 22;
 // The number of pages occupied by the kernel, will need to be increased as we add a heap etc.
 const KERNEL_NUM_PAGES = 1;
 

--- a/src/kernel/arch/x86/constants.zig
+++ b/src/kernel/arch/x86/constants.zig
@@ -1,2 +1,0 @@
-/// The virtual address where the kernel will be loaded. This is at 3GB.
-pub const KERNEL_ADDR_OFFSET = 0xC0000000;

--- a/src/kernel/arch/x86/link.ld
+++ b/src/kernel/arch/x86/link.ld
@@ -1,5 +1,6 @@
 ENTRY(_start)
 
+/* Changes to KERNEL_ADDR_OFFSET must also be made to KERNEL_PAGE_NUMBER in boot.zig */
 KERNEL_ADDR_OFFSET = 0xC0000000;
 KERNEL_VADDR_START = 0xC0100000;
 


### PR DESCRIPTION
We only use constants.zig in x86/boot.zig as everywhere else we use the value exported by the linker﻿ (which I think is the correct approach as that keeps things in sync) so I have removed constants.zig in this PR to make things a little cleaner.
