### PR TITLE
Add syscalls for VFS

### DIFF
--- a/src/kernel/arch/x86/syscalls.zig
+++ b/src/kernel/arch/x86/syscalls.zig
@@ -17,11 +17,7 @@ pub const INTERRUPT: u16 = 0x80;
 pub const NUM_HANDLERS: u16 = 256;
 
 /// A syscall handler
-<<<<<<< HEAD
-pub const Handler = fn (arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) syscalls.Error!usize;
-=======
 pub const Handler = fn (ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) anyerror!usize;
->>>>>>> d3d4298 (Fix error code int types and use anyerror)
 
 /// Errors that syscall utility functions can throw
 pub const Error = error{
@@ -102,272 +98,107 @@ pub fn registerSyscall(syscall: usize, handler: Handler) Error!void {
         return Error.SyscallExists;
     handlers[syscall] = handler;
 }
-
-///
-/// Trigger a syscall with no arguments. Returns the value put in eax by the syscall or the error returned in ebx.
-///
-/// Arguments:
-///     IN syscall: usize - The syscall to trigger, put in eax.
-///
-/// Return: usize
-///     The return value from the syscall.
-///
-/// Error: anyerror
-///     This function will return the error that the syscall handler returns. See the documentation for the syscall for details.
-///
-<<<<<<< HEAD
-inline fn syscall0(syscall: usize) syscalls.Error!usize {
-=======
 fn syscall0(syscall: usize) callconv(.Inline) anyerror!usize {
->>>>>>> d3d4298 (Fix error code int types and use anyerror)
     const res = asm volatile (
         \\int $0x80
-        : [ret] "={eax}" (-> usize),
-        : [syscall] "{eax}" (syscall),
+        : [ret] "={eax}" (-> usize)
+        : [syscall] "{eax}" (syscall)
         : "ebx"
     );
-<<<<<<< HEAD
-    const err = asm (""
-        : [ret] "={ebx}" (-> usize),
-    );
-=======
     const err = @intCast(u16, asm (""
         : [ret] "={ebx}" (-> usize)
     ));
->>>>>>> d3d4298 (Fix error code int types and use anyerror)
     if (err != 0) {
         return syscalls.fromErrorCode(@intCast(u16, err));
     }
     return res;
 }
-
-///
-/// Trigger a syscall with one argument. Returns the value put in eax by the syscall or the error returned in ebx.
-///
-/// Arguments:
-///     IN syscall: usize - The syscall to trigger, put in eax.
-///     IN arg: usize - The argument to pass. Put in ebx.
-///
-/// Return: usize
-///     The return value from the syscall.
-///
-/// Error: anyerror
-///     This function will return the error that the syscall handler returns. See the documentation for the syscall for details.
-///
-<<<<<<< HEAD
-inline fn syscall1(syscall: usize, arg: usize) syscalls.Error!usize {
-=======
 fn syscall1(syscall: usize, arg: usize) callconv(.Inline) anyerror!usize {
->>>>>>> d3d4298 (Fix error code int types and use anyerror)
     const res = asm volatile (
         \\int $0x80
-        : [ret] "={eax}" (-> usize),
+        : [ret] "={eax}" (-> usize)
         : [syscall] "{eax}" (syscall),
-          [arg1] "{ebx}" (arg),
+          [arg1] "{ebx}" (arg)
     );
-<<<<<<< HEAD
-    const err = asm (""
-        : [ret] "={ebx}" (-> usize),
-    );
-=======
     const err = @intCast(u16, asm (""
         : [ret] "={ebx}" (-> usize)
     ));
->>>>>>> d3d4298 (Fix error code int types and use anyerror)
     if (err != 0) {
         return syscalls.fromErrorCode(@intCast(u16, err));
     }
     return res;
 }
-
-///
-/// Trigger a syscall with two arguments. Returns the value put in eax by the syscall or the error returned in ebx.
-///
-/// Arguments:
-///     IN syscall: usize - The syscall to trigger, put in eax.
-///     IN arg1: usize - The first argument to pass. Put in ebx.
-///     IN arg2: usize - The second argument to pass. Put in ecx.
-///
-/// Return: usize
-///     The return value from the syscall.
-///
-/// Error: anyerror
-///     This function will return the error that the syscall handler returns. See the documentation for the syscall for details.
-///
-<<<<<<< HEAD
-inline fn syscall2(syscall: usize, arg1: usize, arg2: usize) syscalls.Error!usize {
-=======
 fn syscall2(syscall: usize, arg1: usize, arg2: usize) callconv(.Inline) anyerror!usize {
->>>>>>> d3d4298 (Fix error code int types and use anyerror)
     const res = asm volatile (
         \\int $0x80
-        : [ret] "={eax}" (-> usize),
+        : [ret] "={eax}" (-> usize)
         : [syscall] "{eax}" (syscall),
           [arg1] "{ebx}" (arg1),
-          [arg2] "{ecx}" (arg2),
+          [arg2] "{ecx}" (arg2)
     );
-<<<<<<< HEAD
-    const err = asm (""
-        : [ret] "={ebx}" (-> usize),
-    );
-=======
     const err = @intCast(u16, asm (""
         : [ret] "={ebx}" (-> usize)
     ));
->>>>>>> d3d4298 (Fix error code int types and use anyerror)
     if (err != 0) {
         return syscalls.fromErrorCode(@intCast(u16, err));
     }
     return res;
 }
-
-///
-/// Trigger a syscall with three arguments. Returns the value put in eax by the syscall or the error returned in ebx.
-///
-/// Arguments:
-///     IN syscall: usize - The syscall to trigger, put in eax.
-///     IN arg1: usize - The first argument to pass. Put in ebx.
-///     IN arg2: usize - The second argument to pass. Put in ecx.
-///     IN arg3: usize - The third argument to pass. Put in edx.
-///
-/// Return: usize
-///     The return value from the syscall.
-///
-/// Error: anyerror
-///     This function will return the error that the syscall handler returns. See the documentation for the syscall for details.
-///
-<<<<<<< HEAD
-inline fn syscall3(syscall: usize, arg1: usize, arg2: usize, arg3: usize) syscalls.Error!usize {
-=======
 fn syscall3(syscall: usize, arg1: usize, arg2: usize, arg3: usize) callconv(.Inline) anyerror!usize {
->>>>>>> d3d4298 (Fix error code int types and use anyerror)
     const res = asm volatile (
         \\int $0x80
-        : [ret] "={eax}" (-> usize),
+        : [ret] "={eax}" (-> usize)
         : [syscall] "{eax}" (syscall),
           [arg1] "{ebx}" (arg1),
           [arg2] "{ecx}" (arg2),
-          [arg3] "{edx}" (arg3),
+          [arg3] "{edx}" (arg3)
     );
-<<<<<<< HEAD
-    const err = asm (""
-        : [ret] "={ebx}" (-> usize),
-    );
-=======
     const err = @intCast(u16, asm (""
         : [ret] "={ebx}" (-> usize)
     ));
->>>>>>> d3d4298 (Fix error code int types and use anyerror)
     if (err != 0) {
         return syscalls.fromErrorCode(@intCast(u16, err));
     }
     return res;
 }
-
-///
-/// Trigger a syscall with four arguments. Returns the value put in eax by the syscall or the error returned in ebx.
-///
-/// Arguments:
-///     IN syscall: usize - The syscall to trigger, put in eax.
-///     IN arg1: usize - The first argument to pass. Put in ebx.
-///     IN arg2: usize - The second argument to pass. Put in ecx.
-///     IN arg3: usize - The third argument to pass. Put in edx.
-///     IN arg4: usize - The fourth argument to pass. Put in esi.
-///
-/// Return: usize
-///     The return value from the syscall.
-///
-/// Error: anyerror
-///     This function will return the error that the syscall handler returns. See the documentation for the syscall for details.
-///
-<<<<<<< HEAD
-inline fn syscall4(syscall: usize, arg1: usize, arg2: usize, arg3: usize, arg4: usize) syscalls.Error!usize {
-=======
 fn syscall4(syscall: usize, arg1: usize, arg2: usize, arg3: usize, arg4: usize) callconv(.Inline) anyerror!usize {
->>>>>>> d3d4298 (Fix error code int types and use anyerror)
     const res = asm volatile (
         \\int $0x80
-        : [ret] "={eax}" (-> usize),
+        : [ret] "={eax}" (-> usize)
         : [syscall] "{eax}" (syscall),
           [arg1] "{ebx}" (arg1),
           [arg2] "{ecx}" (arg2),
           [arg3] "{edx}" (arg3),
-          [arg4] "{esi}" (arg4),
+          [arg4] "{esi}" (arg4)
     );
-<<<<<<< HEAD
-    const err = asm (""
-        : [ret] "={ebx}" (-> usize),
-    );
-=======
     const err = @intCast(u16, asm (""
         : [ret] "={ebx}" (-> usize)
     ));
->>>>>>> d3d4298 (Fix error code int types and use anyerror)
     if (err != 0) {
         return syscalls.fromErrorCode(@intCast(u16, err));
     }
     return res;
 }
-
-///
-/// Trigger a syscall with five arguments. Returns the value put in eax by the syscall or the error returned in ebx.
-///
-/// Arguments:
-///     IN syscall: usize - The syscall to trigger, put in eax.
-///     IN arg1: usize - The first argument to pass. Put in ebx.
-///     IN arg2: usize - The second argument to pass. Put in ecx.
-///     IN arg3: usize - The third argument to pass. Put in edx.
-///     IN arg4: usize - The fourth argument to pass. Put in esi.
-///     IN arg5: usize - The fifth argument to pass. Put in edi.
-///
-/// Return: usize
-///     The return value from the syscall.
-///
-/// Error: anyerror
-///     This function will return the error that the syscall handler returns. See the documentation for the syscall for details.
-///
-<<<<<<< HEAD
-inline fn syscall5(syscall: usize, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) syscalls.Error!usize {
-=======
 fn syscall5(syscall: usize, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) callconv(.Inline) anyerror!usize {
->>>>>>> d3d4298 (Fix error code int types and use anyerror)
     const res = asm volatile (
         \\int $0x80
-        : [ret] "={eax}" (-> usize),
+        : [ret] "={eax}" (-> usize)
         : [syscall] "{eax}" (syscall),
           [arg1] "{ebx}" (arg1),
           [arg2] "{ecx}" (arg2),
           [arg3] "{edx}" (arg3),
           [arg4] "{esi}" (arg4),
-          [arg5] "{edi}" (arg5),
+          [arg5] "{edi}" (arg5)
     );
-<<<<<<< HEAD
-    const err = asm (""
-        : [ret] "={ebx}" (-> usize),
-    );
-=======
     const err = @intCast(u16, asm (""
         : [ret] "={ebx}" (-> usize)
     ));
->>>>>>> d3d4298 (Fix error code int types and use anyerror)
     if (err != 0) {
         return syscalls.fromErrorCode(@intCast(u16, err));
     }
     return res;
 }
-
-///
-/// Gets the syscall argument according to the given index. 0 => ebx, 1 => ecx, 2 => edx,
-/// 3 => esi and 4 => edi.
-///
-/// Arguments:
-///     IN ctx: *arch.CpuState - The interrupt context from which to get the argument
-///     IN arg_idx: comptime u32 - The argument index to get. Between 0 and 4.
-///
-/// Return: usize
-///     The syscall argument from the given index.
-///
-inline fn syscallArg(ctx: *arch.CpuState, comptime arg_idx: u32) usize {
+fn syscallArg(ctx: *arch.CpuState, comptime arg_idx: u32) callconv(.Inline) usize {
     return switch (arg_idx) {
         0 => ctx.ebx,
         1 => ctx.ecx,
@@ -389,11 +220,7 @@ inline fn syscallArg(ctx: *arch.CpuState, comptime arg_idx: u32) usize {
 ///
 fn makeHandler(comptime syscall: syscalls.Syscall) Handler {
     return struct {
-<<<<<<< HEAD
-        fn func(arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) syscalls.Error!usize {
-=======
         fn func(ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) anyerror!usize {
->>>>>>> d3d4298 (Fix error code int types and use anyerror)
             return syscalls.handle(syscall, arg1, arg2, arg3, arg4, arg5);
         }
     }.func;
@@ -428,7 +255,6 @@ pub fn init() void {
 /// Tests
 var test_int: u32 = 0;
 
-<<<<<<< HEAD
 fn testHandler0(arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) syscalls.Error!usize {
     // Suppress unused variable warnings
     _ = arg1;
@@ -436,85 +262,57 @@ fn testHandler0(arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize)
     _ = arg3;
     _ = arg4;
     _ = arg5;
-=======
-fn testHandler0(ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) anyerror!usize {
->>>>>>> d3d4298 (Fix error code int types and use anyerror)
     test_int += 1;
     return 0;
 }
 
-<<<<<<< HEAD
-fn testHandler1(arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) syscalls.Error!usize {
+fn testHandler1(ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) anyerror!usize {
     // Suppress unused variable warnings
     _ = arg2;
     _ = arg3;
     _ = arg4;
     _ = arg5;
-=======
-fn testHandler1(ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) anyerror!usize {
->>>>>>> d3d4298 (Fix error code int types and use anyerror)
     test_int += arg1;
     return 1;
 }
 
-<<<<<<< HEAD
-fn testHandler2(arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) syscalls.Error!usize {
+fn testHandler2(ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) anyerror!usize {
     // Suppress unused variable warnings
     _ = arg3;
     _ = arg4;
     _ = arg5;
-=======
-fn testHandler2(ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) anyerror!usize {
->>>>>>> d3d4298 (Fix error code int types and use anyerror)
     test_int += arg1 + arg2;
     return 2;
 }
 
-<<<<<<< HEAD
-fn testHandler3(arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) syscalls.Error!usize {
+fn testHandler3(ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) anyerror!usize {
     // Suppress unused variable warnings
     _ = arg4;
     _ = arg5;
-=======
-fn testHandler3(ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) anyerror!usize {
->>>>>>> d3d4298 (Fix error code int types and use anyerror)
     test_int += arg1 + arg2 + arg3;
     return 3;
 }
 
-<<<<<<< HEAD
-fn testHandler4(arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) syscalls.Error!usize {
+fn testHandler4(ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) anyerror!usize {
     // Suppress unused variable warnings
     _ = arg5;
-=======
-fn testHandler4(ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) anyerror!usize {
->>>>>>> d3d4298 (Fix error code int types and use anyerror)
     test_int += arg1 + arg2 + arg3 + arg4;
     return 4;
 }
 
-<<<<<<< HEAD
-fn testHandler5(arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) syscalls.Error!usize {
-=======
 fn testHandler5(ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) anyerror!usize {
->>>>>>> d3d4298 (Fix error code int types and use anyerror)
     test_int += arg1 + arg2 + arg3 + arg4 + arg5;
     return 5;
 }
 
-<<<<<<< HEAD
-fn testHandler6(arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) syscalls.Error!usize {
+fn testHandler6(ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) anyerror!usize {
     // Suppress unused variable warnings
     _ = arg1;
     _ = arg2;
     _ = arg3;
     _ = arg4;
     _ = arg5;
-    return syscalls.Error.OutOfMemory;
-=======
-fn testHandler6(ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) anyerror!usize {
     return anyerror.OutOfMemory;
->>>>>>> d3d4298 (Fix error code int types and use anyerror)
 }
 
 test "registerSyscall returns SyscallExists" {

--- a/src/kernel/arch/x86/syscalls.zig
+++ b/src/kernel/arch/x86/syscalls.zig
@@ -32,12 +32,19 @@ comptime {
 /// The array of registered syscalls
 var handlers: [NUM_HANDLERS]?Handler = [_]?Handler{null} ** NUM_HANDLERS;
 
-comptime {
-    std.debug.assert(@typeInfo(Syscall).Enum.fields.len <= NUM_HANDLERS);
+///
+/// Returns true if the syscall is valid, else false.
+/// A syscall is valid if it's less than NUM_HANDLERS.
+///
+/// Arguments:
+///     IN syscall: u32 - The syscall to check
+///
+/// Return: bool
+///     Whether the syscall number is valid.
+///
+pub fn isValidSyscall(syscall: u32) bool {
+    return syscall < NUM_HANDLERS;
 }
-
-/// The array of registered syscalls
-var handlers: [NUM_HANDLERS]?SyscallHandler = [_]?SyscallHandler{null} ** NUM_HANDLERS;
 
 ///
 /// Handle a syscall. Gets the syscall number from eax within the context and calls the registered
@@ -55,7 +62,7 @@ var handlers: [NUM_HANDLERS]?SyscallHandler = [_]?SyscallHandler{null} ** NUM_HA
 fn handle(ctx: *arch.CpuState) usize {
     // The syscall number is put in eax
     const syscall = ctx.eax;
-    if (syscall < NUM_HANDLERS) {
+    if (isValidSyscall(syscall)) {
         if (handlers[syscall]) |handler| {
             const result = handler(syscallArg(ctx, 0), syscallArg(ctx, 1), syscallArg(ctx, 2), syscallArg(ctx, 3), syscallArg(ctx, 4));
             if (result) |res| {

--- a/src/kernel/arch/x86/syscalls.zig
+++ b/src/kernel/arch/x86/syscalls.zig
@@ -64,7 +64,7 @@ fn handle(ctx: *arch.CpuState) usize {
     const syscall = ctx.eax;
     if (isValidSyscall(syscall)) {
         if (handlers[syscall]) |handler| {
-            const result = handler(syscallArg(ctx, 0), syscallArg(ctx, 1), syscallArg(ctx, 2), syscallArg(ctx, 3), syscallArg(ctx, 4));
+            const result = handler(ctx, syscallArg(ctx, 0), syscallArg(ctx, 1), syscallArg(ctx, 2), syscallArg(ctx, 3), syscallArg(ctx, 4));
             if (result) |res| {
                 ctx.eax = res;
                 ctx.ebx = 0;
@@ -98,107 +98,107 @@ pub fn registerSyscall(syscall: usize, handler: Handler) Error!void {
         return Error.SyscallExists;
     handlers[syscall] = handler;
 }
-fn syscall0(syscall: usize) callconv(.Inline) anyerror!usize {
+inline fn syscall0(syscall: usize) anyerror!usize {
     const res = asm volatile (
         \\int $0x80
-        : [ret] "={eax}" (-> usize)
-        : [syscall] "{eax}" (syscall)
+        : [ret] "={eax}" (-> usize),
+        : [syscall] "{eax}" (syscall),
         : "ebx"
     );
     const err = @intCast(u16, asm (""
-        : [ret] "={ebx}" (-> usize)
+        : [ret] "={ebx}" (-> usize),
     ));
     if (err != 0) {
         return syscalls.fromErrorCode(@intCast(u16, err));
     }
     return res;
 }
-fn syscall1(syscall: usize, arg: usize) callconv(.Inline) anyerror!usize {
+inline fn syscall1(syscall: usize, arg: usize) anyerror!usize {
     const res = asm volatile (
         \\int $0x80
-        : [ret] "={eax}" (-> usize)
+        : [ret] "={eax}" (-> usize),
         : [syscall] "{eax}" (syscall),
-          [arg1] "{ebx}" (arg)
+          [arg1] "{ebx}" (arg),
     );
     const err = @intCast(u16, asm (""
-        : [ret] "={ebx}" (-> usize)
+        : [ret] "={ebx}" (-> usize),
     ));
     if (err != 0) {
         return syscalls.fromErrorCode(@intCast(u16, err));
     }
     return res;
 }
-fn syscall2(syscall: usize, arg1: usize, arg2: usize) callconv(.Inline) anyerror!usize {
+inline fn syscall2(syscall: usize, arg1: usize, arg2: usize) anyerror!usize {
     const res = asm volatile (
         \\int $0x80
-        : [ret] "={eax}" (-> usize)
-        : [syscall] "{eax}" (syscall),
-          [arg1] "{ebx}" (arg1),
-          [arg2] "{ecx}" (arg2)
-    );
-    const err = @intCast(u16, asm (""
-        : [ret] "={ebx}" (-> usize)
-    ));
-    if (err != 0) {
-        return syscalls.fromErrorCode(@intCast(u16, err));
-    }
-    return res;
-}
-fn syscall3(syscall: usize, arg1: usize, arg2: usize, arg3: usize) callconv(.Inline) anyerror!usize {
-    const res = asm volatile (
-        \\int $0x80
-        : [ret] "={eax}" (-> usize)
+        : [ret] "={eax}" (-> usize),
         : [syscall] "{eax}" (syscall),
           [arg1] "{ebx}" (arg1),
           [arg2] "{ecx}" (arg2),
-          [arg3] "{edx}" (arg3)
     );
     const err = @intCast(u16, asm (""
-        : [ret] "={ebx}" (-> usize)
+        : [ret] "={ebx}" (-> usize),
     ));
     if (err != 0) {
         return syscalls.fromErrorCode(@intCast(u16, err));
     }
     return res;
 }
-fn syscall4(syscall: usize, arg1: usize, arg2: usize, arg3: usize, arg4: usize) callconv(.Inline) anyerror!usize {
+inline fn syscall3(syscall: usize, arg1: usize, arg2: usize, arg3: usize) anyerror!usize {
     const res = asm volatile (
         \\int $0x80
-        : [ret] "={eax}" (-> usize)
+        : [ret] "={eax}" (-> usize),
         : [syscall] "{eax}" (syscall),
           [arg1] "{ebx}" (arg1),
           [arg2] "{ecx}" (arg2),
           [arg3] "{edx}" (arg3),
-          [arg4] "{esi}" (arg4)
     );
     const err = @intCast(u16, asm (""
-        : [ret] "={ebx}" (-> usize)
+        : [ret] "={ebx}" (-> usize),
     ));
     if (err != 0) {
         return syscalls.fromErrorCode(@intCast(u16, err));
     }
     return res;
 }
-fn syscall5(syscall: usize, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) callconv(.Inline) anyerror!usize {
+inline fn syscall4(syscall: usize, arg1: usize, arg2: usize, arg3: usize, arg4: usize) anyerror!usize {
     const res = asm volatile (
         \\int $0x80
-        : [ret] "={eax}" (-> usize)
+        : [ret] "={eax}" (-> usize),
         : [syscall] "{eax}" (syscall),
           [arg1] "{ebx}" (arg1),
           [arg2] "{ecx}" (arg2),
           [arg3] "{edx}" (arg3),
           [arg4] "{esi}" (arg4),
-          [arg5] "{edi}" (arg5)
     );
     const err = @intCast(u16, asm (""
-        : [ret] "={ebx}" (-> usize)
+        : [ret] "={ebx}" (-> usize),
     ));
     if (err != 0) {
         return syscalls.fromErrorCode(@intCast(u16, err));
     }
     return res;
 }
-fn syscallArg(ctx: *arch.CpuState, comptime arg_idx: u32) callconv(.Inline) usize {
+inline fn syscall5(syscall: usize, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) anyerror!usize {
+    const res = asm volatile (
+        \\int $0x80
+        : [ret] "={eax}" (-> usize),
+        : [syscall] "{eax}" (syscall),
+          [arg1] "{ebx}" (arg1),
+          [arg2] "{ecx}" (arg2),
+          [arg3] "{edx}" (arg3),
+          [arg4] "{esi}" (arg4),
+          [arg5] "{edi}" (arg5),
+    );
+    const err = @intCast(u16, asm (""
+        : [ret] "={ebx}" (-> usize),
+    ));
+    if (err != 0) {
+        return syscalls.fromErrorCode(@intCast(u16, err));
+    }
+    return res;
+}
+inline fn syscallArg(ctx: *arch.CpuState, comptime arg_idx: u32) usize {
     return switch (arg_idx) {
         0 => ctx.ebx,
         1 => ctx.ecx,
@@ -221,6 +221,7 @@ fn syscallArg(ctx: *arch.CpuState, comptime arg_idx: u32) callconv(.Inline) usiz
 fn makeHandler(comptime syscall: syscalls.Syscall) Handler {
     return struct {
         fn func(ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) anyerror!usize {
+            _ = ctx;
             return syscalls.handle(syscall, arg1, arg2, arg3, arg4, arg5);
         }
     }.func;
@@ -255,8 +256,9 @@ pub fn init() void {
 /// Tests
 var test_int: u32 = 0;
 
-fn testHandler0(arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) syscalls.Error!usize {
+fn testHandler0(ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) anyerror!usize {
     // Suppress unused variable warnings
+    _ = ctx;
     _ = arg1;
     _ = arg2;
     _ = arg3;
@@ -268,6 +270,7 @@ fn testHandler0(arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize)
 
 fn testHandler1(ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) anyerror!usize {
     // Suppress unused variable warnings
+    _ = ctx;
     _ = arg2;
     _ = arg3;
     _ = arg4;
@@ -278,6 +281,7 @@ fn testHandler1(ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4
 
 fn testHandler2(ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) anyerror!usize {
     // Suppress unused variable warnings
+    _ = ctx;
     _ = arg3;
     _ = arg4;
     _ = arg5;
@@ -287,6 +291,7 @@ fn testHandler2(ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4
 
 fn testHandler3(ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) anyerror!usize {
     // Suppress unused variable warnings
+    _ = ctx;
     _ = arg4;
     _ = arg5;
     test_int += arg1 + arg2 + arg3;
@@ -295,18 +300,21 @@ fn testHandler3(ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4
 
 fn testHandler4(ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) anyerror!usize {
     // Suppress unused variable warnings
+    _ = ctx;
     _ = arg5;
     test_int += arg1 + arg2 + arg3 + arg4;
     return 4;
 }
 
 fn testHandler5(ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) anyerror!usize {
+    _ = ctx;
     test_int += arg1 + arg2 + arg3 + arg4 + arg5;
     return 5;
 }
 
 fn testHandler6(ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) anyerror!usize {
     // Suppress unused variable warnings
+    _ = ctx;
     _ = arg1;
     _ = arg2;
     _ = arg3;

--- a/src/kernel/arch/x86/syscalls.zig
+++ b/src/kernel/arch/x86/syscalls.zig
@@ -32,19 +32,12 @@ comptime {
 /// The array of registered syscalls
 var handlers: [NUM_HANDLERS]?Handler = [_]?Handler{null} ** NUM_HANDLERS;
 
-///
-/// Returns true if the syscall is valid, else false.
-/// A syscall is valid if it's less than NUM_HANDLERS.
-///
-/// Arguments:
-///     IN syscall: u32 - The syscall to check
-///
-/// Return: bool
-///     Whether the syscall number is valid.
-///
-pub fn isValidSyscall(syscall: u32) bool {
-    return syscall < NUM_HANDLERS;
+comptime {
+    std.debug.assert(@typeInfo(Syscall).Enum.fields.len <= NUM_HANDLERS);
 }
+
+/// The array of registered syscalls
+var handlers: [NUM_HANDLERS]?SyscallHandler = [_]?SyscallHandler{null} ** NUM_HANDLERS;
 
 ///
 /// Handle a syscall. Gets the syscall number from eax within the context and calls the registered
@@ -62,7 +55,7 @@ pub fn isValidSyscall(syscall: u32) bool {
 fn handle(ctx: *arch.CpuState) usize {
     // The syscall number is put in eax
     const syscall = ctx.eax;
-    if (isValidSyscall(syscall)) {
+    if (syscall < NUM_HANDLERS) {
         if (handlers[syscall]) |handler| {
             const result = handler(syscallArg(ctx, 0), syscallArg(ctx, 1), syscallArg(ctx, 2), syscallArg(ctx, 3), syscallArg(ctx, 4));
             if (result) |res| {

--- a/src/kernel/arch/x86/syscalls.zig
+++ b/src/kernel/arch/x86/syscalls.zig
@@ -17,7 +17,11 @@ pub const INTERRUPT: u16 = 0x80;
 pub const NUM_HANDLERS: u16 = 256;
 
 /// A syscall handler
+<<<<<<< HEAD
 pub const Handler = fn (arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) syscalls.Error!usize;
+=======
+pub const Handler = fn (ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) anyerror!usize;
+>>>>>>> d3d4298 (Fix error code int types and use anyerror)
 
 /// Errors that syscall utility functions can throw
 pub const Error = error{
@@ -108,21 +112,31 @@ pub fn registerSyscall(syscall: usize, handler: Handler) Error!void {
 /// Return: usize
 ///     The return value from the syscall.
 ///
-/// Error: syscalls.Error
+/// Error: anyerror
 ///     This function will return the error that the syscall handler returns. See the documentation for the syscall for details.
 ///
+<<<<<<< HEAD
 inline fn syscall0(syscall: usize) syscalls.Error!usize {
+=======
+fn syscall0(syscall: usize) callconv(.Inline) anyerror!usize {
+>>>>>>> d3d4298 (Fix error code int types and use anyerror)
     const res = asm volatile (
         \\int $0x80
         : [ret] "={eax}" (-> usize),
         : [syscall] "{eax}" (syscall),
         : "ebx"
     );
+<<<<<<< HEAD
     const err = asm (""
         : [ret] "={ebx}" (-> usize),
     );
+=======
+    const err = @intCast(u16, asm (""
+        : [ret] "={ebx}" (-> usize)
+    ));
+>>>>>>> d3d4298 (Fix error code int types and use anyerror)
     if (err != 0) {
-        return syscalls.fromErrorCode(err);
+        return syscalls.fromErrorCode(@intCast(u16, err));
     }
     return res;
 }
@@ -137,21 +151,31 @@ inline fn syscall0(syscall: usize) syscalls.Error!usize {
 /// Return: usize
 ///     The return value from the syscall.
 ///
-/// Error: syscalls.Error
+/// Error: anyerror
 ///     This function will return the error that the syscall handler returns. See the documentation for the syscall for details.
 ///
+<<<<<<< HEAD
 inline fn syscall1(syscall: usize, arg: usize) syscalls.Error!usize {
+=======
+fn syscall1(syscall: usize, arg: usize) callconv(.Inline) anyerror!usize {
+>>>>>>> d3d4298 (Fix error code int types and use anyerror)
     const res = asm volatile (
         \\int $0x80
         : [ret] "={eax}" (-> usize),
         : [syscall] "{eax}" (syscall),
           [arg1] "{ebx}" (arg),
     );
+<<<<<<< HEAD
     const err = asm (""
         : [ret] "={ebx}" (-> usize),
     );
+=======
+    const err = @intCast(u16, asm (""
+        : [ret] "={ebx}" (-> usize)
+    ));
+>>>>>>> d3d4298 (Fix error code int types and use anyerror)
     if (err != 0) {
-        return syscalls.fromErrorCode(err);
+        return syscalls.fromErrorCode(@intCast(u16, err));
     }
     return res;
 }
@@ -167,10 +191,14 @@ inline fn syscall1(syscall: usize, arg: usize) syscalls.Error!usize {
 /// Return: usize
 ///     The return value from the syscall.
 ///
-/// Error: syscalls.Error
+/// Error: anyerror
 ///     This function will return the error that the syscall handler returns. See the documentation for the syscall for details.
 ///
+<<<<<<< HEAD
 inline fn syscall2(syscall: usize, arg1: usize, arg2: usize) syscalls.Error!usize {
+=======
+fn syscall2(syscall: usize, arg1: usize, arg2: usize) callconv(.Inline) anyerror!usize {
+>>>>>>> d3d4298 (Fix error code int types and use anyerror)
     const res = asm volatile (
         \\int $0x80
         : [ret] "={eax}" (-> usize),
@@ -178,11 +206,17 @@ inline fn syscall2(syscall: usize, arg1: usize, arg2: usize) syscalls.Error!usiz
           [arg1] "{ebx}" (arg1),
           [arg2] "{ecx}" (arg2),
     );
+<<<<<<< HEAD
     const err = asm (""
         : [ret] "={ebx}" (-> usize),
     );
+=======
+    const err = @intCast(u16, asm (""
+        : [ret] "={ebx}" (-> usize)
+    ));
+>>>>>>> d3d4298 (Fix error code int types and use anyerror)
     if (err != 0) {
-        return syscalls.fromErrorCode(err);
+        return syscalls.fromErrorCode(@intCast(u16, err));
     }
     return res;
 }
@@ -199,10 +233,14 @@ inline fn syscall2(syscall: usize, arg1: usize, arg2: usize) syscalls.Error!usiz
 /// Return: usize
 ///     The return value from the syscall.
 ///
-/// Error: syscalls.Error
+/// Error: anyerror
 ///     This function will return the error that the syscall handler returns. See the documentation for the syscall for details.
 ///
+<<<<<<< HEAD
 inline fn syscall3(syscall: usize, arg1: usize, arg2: usize, arg3: usize) syscalls.Error!usize {
+=======
+fn syscall3(syscall: usize, arg1: usize, arg2: usize, arg3: usize) callconv(.Inline) anyerror!usize {
+>>>>>>> d3d4298 (Fix error code int types and use anyerror)
     const res = asm volatile (
         \\int $0x80
         : [ret] "={eax}" (-> usize),
@@ -211,11 +249,17 @@ inline fn syscall3(syscall: usize, arg1: usize, arg2: usize, arg3: usize) syscal
           [arg2] "{ecx}" (arg2),
           [arg3] "{edx}" (arg3),
     );
+<<<<<<< HEAD
     const err = asm (""
         : [ret] "={ebx}" (-> usize),
     );
+=======
+    const err = @intCast(u16, asm (""
+        : [ret] "={ebx}" (-> usize)
+    ));
+>>>>>>> d3d4298 (Fix error code int types and use anyerror)
     if (err != 0) {
-        return syscalls.fromErrorCode(err);
+        return syscalls.fromErrorCode(@intCast(u16, err));
     }
     return res;
 }
@@ -233,10 +277,14 @@ inline fn syscall3(syscall: usize, arg1: usize, arg2: usize, arg3: usize) syscal
 /// Return: usize
 ///     The return value from the syscall.
 ///
-/// Error: syscalls.Error
+/// Error: anyerror
 ///     This function will return the error that the syscall handler returns. See the documentation for the syscall for details.
 ///
+<<<<<<< HEAD
 inline fn syscall4(syscall: usize, arg1: usize, arg2: usize, arg3: usize, arg4: usize) syscalls.Error!usize {
+=======
+fn syscall4(syscall: usize, arg1: usize, arg2: usize, arg3: usize, arg4: usize) callconv(.Inline) anyerror!usize {
+>>>>>>> d3d4298 (Fix error code int types and use anyerror)
     const res = asm volatile (
         \\int $0x80
         : [ret] "={eax}" (-> usize),
@@ -246,11 +294,17 @@ inline fn syscall4(syscall: usize, arg1: usize, arg2: usize, arg3: usize, arg4: 
           [arg3] "{edx}" (arg3),
           [arg4] "{esi}" (arg4),
     );
+<<<<<<< HEAD
     const err = asm (""
         : [ret] "={ebx}" (-> usize),
     );
+=======
+    const err = @intCast(u16, asm (""
+        : [ret] "={ebx}" (-> usize)
+    ));
+>>>>>>> d3d4298 (Fix error code int types and use anyerror)
     if (err != 0) {
-        return syscalls.fromErrorCode(err);
+        return syscalls.fromErrorCode(@intCast(u16, err));
     }
     return res;
 }
@@ -269,10 +323,14 @@ inline fn syscall4(syscall: usize, arg1: usize, arg2: usize, arg3: usize, arg4: 
 /// Return: usize
 ///     The return value from the syscall.
 ///
-/// Error: syscalls.Error
+/// Error: anyerror
 ///     This function will return the error that the syscall handler returns. See the documentation for the syscall for details.
 ///
+<<<<<<< HEAD
 inline fn syscall5(syscall: usize, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) syscalls.Error!usize {
+=======
+fn syscall5(syscall: usize, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) callconv(.Inline) anyerror!usize {
+>>>>>>> d3d4298 (Fix error code int types and use anyerror)
     const res = asm volatile (
         \\int $0x80
         : [ret] "={eax}" (-> usize),
@@ -283,11 +341,17 @@ inline fn syscall5(syscall: usize, arg1: usize, arg2: usize, arg3: usize, arg4: 
           [arg4] "{esi}" (arg4),
           [arg5] "{edi}" (arg5),
     );
+<<<<<<< HEAD
     const err = asm (""
         : [ret] "={ebx}" (-> usize),
     );
+=======
+    const err = @intCast(u16, asm (""
+        : [ret] "={ebx}" (-> usize)
+    ));
+>>>>>>> d3d4298 (Fix error code int types and use anyerror)
     if (err != 0) {
-        return syscalls.fromErrorCode(err);
+        return syscalls.fromErrorCode(@intCast(u16, err));
     }
     return res;
 }
@@ -325,7 +389,11 @@ inline fn syscallArg(ctx: *arch.CpuState, comptime arg_idx: u32) usize {
 ///
 fn makeHandler(comptime syscall: syscalls.Syscall) Handler {
     return struct {
+<<<<<<< HEAD
         fn func(arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) syscalls.Error!usize {
+=======
+        fn func(ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) anyerror!usize {
+>>>>>>> d3d4298 (Fix error code int types and use anyerror)
             return syscalls.handle(syscall, arg1, arg2, arg3, arg4, arg5);
         }
     }.func;
@@ -360,6 +428,7 @@ pub fn init() void {
 /// Tests
 var test_int: u32 = 0;
 
+<<<<<<< HEAD
 fn testHandler0(arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) syscalls.Error!usize {
     // Suppress unused variable warnings
     _ = arg1;
@@ -367,49 +436,73 @@ fn testHandler0(arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize)
     _ = arg3;
     _ = arg4;
     _ = arg5;
+=======
+fn testHandler0(ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) anyerror!usize {
+>>>>>>> d3d4298 (Fix error code int types and use anyerror)
     test_int += 1;
     return 0;
 }
 
+<<<<<<< HEAD
 fn testHandler1(arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) syscalls.Error!usize {
     // Suppress unused variable warnings
     _ = arg2;
     _ = arg3;
     _ = arg4;
     _ = arg5;
+=======
+fn testHandler1(ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) anyerror!usize {
+>>>>>>> d3d4298 (Fix error code int types and use anyerror)
     test_int += arg1;
     return 1;
 }
 
+<<<<<<< HEAD
 fn testHandler2(arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) syscalls.Error!usize {
     // Suppress unused variable warnings
     _ = arg3;
     _ = arg4;
     _ = arg5;
+=======
+fn testHandler2(ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) anyerror!usize {
+>>>>>>> d3d4298 (Fix error code int types and use anyerror)
     test_int += arg1 + arg2;
     return 2;
 }
 
+<<<<<<< HEAD
 fn testHandler3(arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) syscalls.Error!usize {
     // Suppress unused variable warnings
     _ = arg4;
     _ = arg5;
+=======
+fn testHandler3(ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) anyerror!usize {
+>>>>>>> d3d4298 (Fix error code int types and use anyerror)
     test_int += arg1 + arg2 + arg3;
     return 3;
 }
 
+<<<<<<< HEAD
 fn testHandler4(arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) syscalls.Error!usize {
     // Suppress unused variable warnings
     _ = arg5;
+=======
+fn testHandler4(ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) anyerror!usize {
+>>>>>>> d3d4298 (Fix error code int types and use anyerror)
     test_int += arg1 + arg2 + arg3 + arg4;
     return 4;
 }
 
+<<<<<<< HEAD
 fn testHandler5(arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) syscalls.Error!usize {
+=======
+fn testHandler5(ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) anyerror!usize {
+>>>>>>> d3d4298 (Fix error code int types and use anyerror)
     test_int += arg1 + arg2 + arg3 + arg4 + arg5;
     return 5;
 }
 
+<<<<<<< HEAD
 fn testHandler6(arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) syscalls.Error!usize {
     // Suppress unused variable warnings
     _ = arg1;
@@ -418,6 +511,10 @@ fn testHandler6(arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize)
     _ = arg4;
     _ = arg5;
     return syscalls.Error.OutOfMemory;
+=======
+fn testHandler6(ctx: *arch.CpuState, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) anyerror!usize {
+    return anyerror.OutOfMemory;
+>>>>>>> d3d4298 (Fix error code int types and use anyerror)
 }
 
 test "registerSyscall returns SyscallExists" {
@@ -489,7 +586,7 @@ fn runtimeTests() void {
     if (syscall0(121)) {
         panic(@errorReturnTrace(), "FAILURE syscall6\n", .{});
     } else |e| {
-        if (e != syscalls.Error.OutOfMemory) {
+        if (e != error.OutOfMemory) {
             panic(@errorReturnTrace(), "FAILURE syscall6 returned the wrong error: {}\n", .{e});
         }
     }

--- a/src/kernel/arch/x86/syscalls.zig
+++ b/src/kernel/arch/x86/syscalls.zig
@@ -344,9 +344,11 @@ pub fn init() void {
 
     inline for (std.meta.fields(syscalls.Syscall)) |field| {
         const syscall = @intToEnum(syscalls.Syscall, field.value);
-        registerSyscall(field.value, makeHandler(syscall)) catch |e| {
-            panic(@errorReturnTrace(), "Failed to register syscall for '" ++ field.name ++ "': {}\n", .{e});
-        };
+        if (!syscall.isTest()) {
+            registerSyscall(field.value, makeHandler(syscall)) catch |e| {
+                panic(@errorReturnTrace(), "Failed to register syscall for '" ++ field.name ++ "': {}\n", .{e});
+            };
+        }
     }
 
     switch (build_options.test_mode) {

--- a/src/kernel/bitmap.zig
+++ b/src/kernel/bitmap.zig
@@ -1,205 +1,31 @@
 const std = @import("std");
 const builtin = std.builtin;
 const testing = std.testing;
+const expectEqual = testing.expectEqual;
 const Allocator = std.mem.Allocator;
 
-///
-/// A comptime bitmap that uses a specific type to store the entries. No allocators needed.
-///
-/// Arguments:
-///     IN BitmapType: type - The integer type to use to store entries.
-///
-/// Return: type.
-///     The bitmap type created.
-///
-pub fn ComptimeBitmap(comptime BitmapType: type) type {
-    return struct {
-        const Self = @This();
-
-        /// The number of entries that one bitmap type can hold. Evaluates to the number of bits the type has
-        pub const NUM_ENTRIES: usize = std.meta.bitCount(BitmapType);
-
-        /// The value that a full bitmap will have
-        pub const BITMAP_FULL = std.math.maxInt(BitmapType);
-
-        /// The type of an index into a bitmap entry. The smallest integer needed to represent all bit positions in the bitmap entry type
-        pub const IndexType = std.meta.Int(.unsigned, std.math.log2(std.math.ceilPowerOfTwo(u16, std.meta.bitCount(BitmapType)) catch unreachable));
-
-        bitmap: BitmapType,
-        num_free_entries: BitmapType,
-
-        ///
-        /// Create an instance of this bitmap type.
-        ///
-        /// Return: Self.
-        ///     The bitmap instance.
-        ///
-        pub fn init() Self {
-            return .{
-                .bitmap = 0,
-                .num_free_entries = NUM_ENTRIES,
-            };
-        }
-
-        ///
-        /// Set an entry within a bitmap as occupied.
-        ///
-        /// Arguments:
-        ///     IN/OUT self: *Self - The bitmap to modify.
-        ///     IN idx: IndexType - The index within the bitmap to set.
-        ///
-        pub fn setEntry(self: *Self, idx: IndexType) void {
-            if (!self.isSet(idx)) {
-                self.bitmap |= indexToBit(idx);
-                self.num_free_entries -= 1;
-            }
-        }
-
-        ///
-        /// Set an entry within a bitmap as unoccupied.
-        ///
-        /// Arguments:
-        ///     IN/OUT self: *Self - The bitmap to modify.
-        ///     IN idx: IndexType - The index within the bitmap to clear.
-        ///
-        pub fn clearEntry(self: *Self, idx: IndexType) void {
-            if (self.isSet(idx)) {
-                self.bitmap &= ~indexToBit(idx);
-                self.num_free_entries += 1;
-            }
-        }
-
-        ///
-        /// Convert a global bitmap index into the bit corresponding to an entry within a single BitmapType.
-        ///
-        /// Arguments:
-        ///     IN self: *const Self - The bitmap to use.
-        ///     IN idx: IndexType - The index into all of the bitmaps entries.
-        ///
-        /// Return: BitmapType.
-        ///     The bit corresponding to that index but within a single BitmapType.
-        ///
-        fn indexToBit(idx: IndexType) BitmapType {
-            return @as(BitmapType, 1) << idx;
-        }
-
-        ///
-        /// Find a number of contiguous free entries and set them.
-        ///
-        /// Arguments:
-        ///     IN/OUT self: *Self - The bitmap to modify.
-        ///     IN num: usize - The number of entries to set.
-        ///     IN from: ?IndexType - The entry number to start allocate from or null if it can start anywhere
-        ///
-        /// Return: ?IndexType
-        ///     The first entry set or null if there weren't enough contiguous entries.
-        ///     If `from` was not null and any entry between `from` and `from` + num is set then null is returned.
-        ///
-        pub fn setContiguous(self: *Self, num: usize, from: ?IndexType) ?IndexType {
-            if (num > self.num_free_entries) {
-                return null;
-            }
-
-            var count: usize = 0;
-            var start: ?IndexType = null;
-
-            var bit = from orelse 0;
-            while (true) {
-                const entry = bit;
-                if (entry >= NUM_ENTRIES) {
-                    return null;
-                }
-                if ((self.bitmap & @as(BitmapType, 1) << bit) != 0) {
-                    // This is a one so clear the progress
-                    count = 0;
-                    start = null;
-                    // If the caller requested the allocation to start from
-                    // a specific entry and it failed then return null
-                    if (from) |_| {
-                        return null;
-                    }
-                } else {
-                    // It's a zero so increment the count
-                    count += 1;
-                    if (start == null) {
-                        // Start of the contiguous zeroes
-                        start = entry;
-                    }
-                    if (count == num) {
-                        // Reached the desired number
-                        break;
-                    }
-                }
-                // Avoiding overflow by checking if bit is less than the max - 1
-                if (bit < NUM_ENTRIES - 1) {
-                    bit += 1;
-                } else {
-                    break;
-                }
-            }
-
-            if (count == num) {
-                if (start) |start_entry| {
-                    var i: IndexType = 0;
-                    while (i < num) : (i += 1) {
-                        self.setEntry(start_entry + i);
-                    }
-                    return start_entry;
-                }
-            }
-            return null;
-        }
-
-        ///
-        /// Set the first free entry within the bitmaps as occupied.
-        ///
-        /// Return: ?IndexType.
-        ///     The index within all bitmaps that was set or null if there wasn't one free.
-        ///     0 .. NUM_ENTRIES - 1 if in the first bitmap, NUM_ENTRIES .. NUM_ENTRIES * 2 - 1 if in the second etc.
-        ///
-        pub fn setFirstFree(self: *Self) ?IndexType {
-            if (self.num_free_entries == 0 or self.bitmap == BITMAP_FULL) {
-                std.debug.assert(self.num_free_entries == 0 and self.bitmap == BITMAP_FULL);
-                return null;
-            }
-            const bit = @truncate(IndexType, @ctz(BitmapType, ~self.bitmap));
-            self.setEntry(bit);
-            return bit;
-        }
-
-        ///
-        /// Check if an entry is set.
-        ///
-        /// Arguments:
-        ///     IN self: *const Self - The bitmap to check.
-        ///     IN idx: usize - The entry to check.
-        ///
-        /// Return: bool.
-        ///     True if the entry is set, else false.
-        ///
-        pub fn isSet(self: *const Self, idx: IndexType) bool {
-            return (self.bitmap & indexToBit(idx)) != 0;
-        }
-    };
-}
+/// The possible errors thrown by bitmap functions
+pub const BitmapError = error{
+    /// The address given was outside the region covered by a bitmap
+    OutOfBounds,
+};
 
 ///
 /// A bitmap that uses a specific type to store the entries.
+/// The bitmap can either be statically or dynamically allocated.
+/// Statically allocated bitmaps are allocated at compile time and therefore must know the number of entries at compile time.
+/// Dynamically allocated bitmaps do not need to know the number of entries until being initialised, but do need an allocator.
 ///
 /// Arguments:
+///     IN static: comptime bool - Whether this bitmap is statically or dynamically allocated
 ///     IN BitmapType: type - The integer type to use to store entries.
+///     IN num_entries: usize or ?usize - The number of entries if static, else ignored (can be null)
 ///
 /// Return: type.
 ///     The bitmap type created.
 ///
-pub fn Bitmap(comptime BitmapType: type) type {
+pub fn Bitmap(comptime static: bool, comptime BitmapType: type, comptime num_entries: if (static) usize else ?usize) type {
     return struct {
-        /// The possible errors thrown by bitmap functions
-        pub const BitmapError = error{
-            /// The address given was outside the region covered by a bitmap
-            OutOfBounds,
-        };
-
         const Self = @This();
 
         /// The number of entries that one bitmap type can hold. Evaluates to the number of bits the type has
@@ -213,37 +39,48 @@ pub fn Bitmap(comptime BitmapType: type) type {
 
         num_bitmaps: usize,
         num_entries: usize,
-        bitmaps: []BitmapType,
+        bitmaps: if (static) [std.mem.alignForward(num_entries, ENTRIES_PER_BITMAP) / ENTRIES_PER_BITMAP]BitmapType else []BitmapType,
         num_free_entries: usize,
-        allocator: Allocator,
+        allocator: if (static) ?Allocator else Allocator,
 
         ///
         /// Create an instance of this bitmap type.
         ///
         /// Arguments:
-        ///     IN num_entries: usize - The number of entries that the bitmap created will have.
-        ///         The number of BitmapType required to store this many entries will be allocated and each will be zeroed.
-        ///     IN allocator: Allocator - The allocator to use when allocating the BitmapTypes required.
+        ///     IN num: ?usize or usize - The number of entries that the bitmap created will have if dynamically allocated, else ignored (can be null)
+        ///         The number of BitmapType required to store this many entries will be allocated (dynamically or statically) and each will be zeroed.
+        ///     IN allocator: ?Allocator or Allocator - The allocator to use when allocating the BitmapTypes required. Ignored if statically allocated.
         ///
         /// Return: Self.
         ///     The bitmap instance.
         ///
         /// Error: Allocator.Error
-        ///     OutOfMemory: There isn't enough memory available to allocate the required number of BitmapType.
+        ///     OutOfMemory: There isn't enough memory available to allocate the required number of BitmapType. A statically allocated bitmap will not throw this error.
         ///
-        pub fn init(num_entries: usize, allocator: Allocator) !Self {
-            const num = std.mem.alignForward(num_entries, ENTRIES_PER_BITMAP) / ENTRIES_PER_BITMAP;
-            const self = Self{
-                .num_bitmaps = num,
-                .num_entries = num_entries,
-                .bitmaps = try allocator.alloc(BitmapType, num),
-                .num_free_entries = num_entries,
-                .allocator = allocator,
-            };
-            for (self.bitmaps) |*bmp| {
-                bmp.* = 0;
+        pub fn init(num: if (static) ?usize else usize, allocator: if (static) ?Allocator else Allocator) !Self {
+            if (static) {
+                const n = std.mem.alignForward(num_entries, ENTRIES_PER_BITMAP) / ENTRIES_PER_BITMAP;
+                return Self{
+                    .num_bitmaps = n,
+                    .bitmaps = [_]BitmapType{0} ** (std.mem.alignForward(num_entries, ENTRIES_PER_BITMAP) / ENTRIES_PER_BITMAP),
+                    .num_entries = num_entries,
+                    .num_free_entries = num_entries,
+                    .allocator = null,
+                };
+            } else {
+                const n = std.mem.alignForward(num, ENTRIES_PER_BITMAP) / ENTRIES_PER_BITMAP;
+                const self = Self{
+                    .num_bitmaps = n,
+                    .num_entries = num,
+                    .bitmaps = try allocator.alloc(BitmapType, n),
+                    .num_free_entries = num,
+                    .allocator = allocator,
+                };
+                for (self.bitmaps) |*bmp| {
+                    bmp.* = 0;
+                }
+                return self;
             }
-            return self;
         }
 
         ///
@@ -271,12 +108,13 @@ pub fn Bitmap(comptime BitmapType: type) type {
 
         ///
         /// Free the memory occupied by this bitmap's internal state. It will become unusable afterwards.
+        /// Does nothing if the bitmap was statically allocated.
         ///
         /// Arguments:
         ///     IN self: *Self - The bitmap that should be deinitialised
         ///
         pub fn deinit(self: *Self) void {
-            self.allocator.free(self.bitmaps);
+            if (!static) self.allocator.free(self.bitmaps);
         }
 
         ///
@@ -459,102 +297,113 @@ pub fn Bitmap(comptime BitmapType: type) type {
     };
 }
 
-test "Comptime setEntry" {
-    var bmp = ComptimeBitmap(u32).init();
+test "static setEntry" {
+    var bmp = try Bitmap(true, u32, 32).init(null, null);
+    try testing.expectEqual(@as(u32, 1), bmp.bitmaps.len);
     try testing.expectEqual(@as(u32, 32), bmp.num_free_entries);
 
-    bmp.setEntry(0);
-    try testing.expectEqual(@as(u32, 1), bmp.bitmap);
+    try bmp.setEntry(0);
+    try testing.expectEqual(@as(u32, 1), bmp.bitmaps[0]);
     try testing.expectEqual(@as(u32, 31), bmp.num_free_entries);
 
-    bmp.setEntry(1);
-    try testing.expectEqual(@as(u32, 3), bmp.bitmap);
+    try bmp.setEntry(1);
+    try testing.expectEqual(@as(u32, 3), bmp.bitmaps[0]);
     try testing.expectEqual(@as(u32, 30), bmp.num_free_entries);
 
     // Repeat setting entry 1 to make sure state doesn't change
-    bmp.setEntry(1);
-    try testing.expectEqual(@as(u32, 3), bmp.bitmap);
+    try bmp.setEntry(1);
+    try testing.expectEqual(@as(u32, 3), bmp.bitmaps[0]);
     try testing.expectEqual(@as(u32, 30), bmp.num_free_entries);
 }
 
-test "Comptime clearEntry" {
-    var bmp = ComptimeBitmap(u32).init();
+test "static clearEntry" {
+    var bmp = try Bitmap(true, u32, 32).init(null, null);
+    try testing.expectEqual(@as(u32, 1), bmp.bitmaps.len);
     try testing.expectEqual(@as(u32, 32), bmp.num_free_entries);
 
-    bmp.setEntry(0);
+    try bmp.setEntry(0);
     try testing.expectEqual(@as(u32, 31), bmp.num_free_entries);
-    bmp.setEntry(1);
+    try bmp.setEntry(1);
     try testing.expectEqual(@as(u32, 30), bmp.num_free_entries);
-    try testing.expectEqual(@as(u32, 3), bmp.bitmap);
-    bmp.clearEntry(0);
+    try testing.expectEqual(@as(u32, 3), bmp.bitmaps[0]);
+    try bmp.clearEntry(0);
     try testing.expectEqual(@as(u32, 31), bmp.num_free_entries);
-    try testing.expectEqual(@as(u32, 2), bmp.bitmap);
+    try testing.expectEqual(@as(u32, 2), bmp.bitmaps[0]);
 
     // Repeat to make sure state doesn't change
-    bmp.clearEntry(0);
+    try bmp.clearEntry(0);
     try testing.expectEqual(@as(u32, 31), bmp.num_free_entries);
-    try testing.expectEqual(@as(u32, 2), bmp.bitmap);
+    try testing.expectEqual(@as(u32, 2), bmp.bitmaps[0]);
 
     // Try clearing an unset entry to make sure state doesn't change
-    bmp.clearEntry(2);
+    try bmp.clearEntry(2);
     try testing.expectEqual(@as(u32, 31), bmp.num_free_entries);
-    try testing.expectEqual(@as(u32, 2), bmp.bitmap);
+    try testing.expectEqual(@as(u32, 2), bmp.bitmaps[0]);
 }
 
-test "Comptime setFirstFree" {
-    var bmp = ComptimeBitmap(u32).init();
+test "static setFirstFree" {
+    var bmp = try Bitmap(true, u32, 32).init(null, null);
+    try testing.expectEqual(@as(u32, 1), bmp.bitmaps.len);
 
     // Allocate the first entry
     try testing.expectEqual(bmp.setFirstFree() orelse unreachable, 0);
-    try testing.expectEqual(bmp.bitmap, 1);
+    try testing.expectEqual(bmp.bitmaps[0], 1);
 
     // Allocate the second entry
     try testing.expectEqual(bmp.setFirstFree() orelse unreachable, 1);
-    try testing.expectEqual(bmp.bitmap, 3);
+    try testing.expectEqual(bmp.bitmaps[0], 3);
 
     // Make all but the MSB occupied and try to allocate it
-    bmp.bitmap = ComptimeBitmap(u32).BITMAP_FULL & ~@as(u32, 1 << (ComptimeBitmap(u32).NUM_ENTRIES - 1));
+    for (bmp.bitmaps) |*b, i| {
+        b.* = @TypeOf(bmp).BITMAP_FULL;
+        if (i <= bmp.num_bitmaps - 1) b.* &= ~(@as(usize, 1) << @TypeOf(bmp).ENTRIES_PER_BITMAP - 1);
+    }
     bmp.num_free_entries = 1;
-    try testing.expectEqual(bmp.setFirstFree() orelse unreachable, ComptimeBitmap(u32).NUM_ENTRIES - 1);
-    try testing.expectEqual(bmp.bitmap, ComptimeBitmap(u32).BITMAP_FULL);
+    try testing.expectEqual(bmp.setFirstFree() orelse unreachable, bmp.num_entries - 1);
+    for (bmp.bitmaps) |b| {
+        try testing.expectEqual(b, @TypeOf(bmp).BITMAP_FULL);
+    }
 
     // We should no longer be able to allocate any entries
     try testing.expectEqual(bmp.setFirstFree(), null);
-    try testing.expectEqual(bmp.bitmap, ComptimeBitmap(u32).BITMAP_FULL);
+    for (bmp.bitmaps) |b| {
+        try testing.expectEqual(b, @TypeOf(bmp).BITMAP_FULL);
+    }
 }
 
-test "Comptime isSet" {
-    var bmp = ComptimeBitmap(u32).init();
+test "static isSet" {
+    var bmp = try Bitmap(true, u32, 32).init(null, null);
+    try testing.expectEqual(@as(u32, 1), bmp.bitmaps.len);
 
-    bmp.bitmap = 1;
+    bmp.bitmaps[0] = 1;
     // Make sure that only the set entry is considered set
-    try testing.expect(bmp.isSet(0));
+    try testing.expect(try bmp.isSet(0));
     var i: usize = 1;
-    while (i < ComptimeBitmap(u32).NUM_ENTRIES) : (i += 1) {
-        try testing.expect(!bmp.isSet(@truncate(ComptimeBitmap(u32).IndexType, i)));
+    while (i < bmp.num_entries) : (i += 1) {
+        try testing.expect(!(try bmp.isSet(@truncate(@TypeOf(bmp).IndexType, i))));
     }
 
-    bmp.bitmap = 3;
-    try testing.expect(bmp.isSet(0));
-    try testing.expect(bmp.isSet(1));
+    bmp.bitmaps[0] = 3;
+    try testing.expect(try bmp.isSet(0));
+    try testing.expect(try bmp.isSet(1));
     i = 2;
-    while (i < ComptimeBitmap(u32).NUM_ENTRIES) : (i += 1) {
-        try testing.expect(!bmp.isSet(@truncate(ComptimeBitmap(u32).IndexType, i)));
+    while (i < bmp.num_entries) : (i += 1) {
+        try testing.expect(!(try bmp.isSet(@truncate(@TypeOf(bmp).IndexType, i))));
     }
 
-    bmp.bitmap = 11;
-    try testing.expect(bmp.isSet(0));
-    try testing.expect(bmp.isSet(1));
-    try testing.expect(!bmp.isSet(2));
-    try testing.expect(bmp.isSet(3));
+    bmp.bitmaps[0] = 11;
+    try testing.expect(try bmp.isSet(0));
+    try testing.expect(try bmp.isSet(1));
+    try testing.expect(!(try bmp.isSet(2)));
+    try testing.expect(try bmp.isSet(3));
     i = 4;
-    while (i < ComptimeBitmap(u32).NUM_ENTRIES) : (i += 1) {
-        try testing.expect(!bmp.isSet(@truncate(ComptimeBitmap(u32).IndexType, i)));
+    while (i < bmp.num_entries) : (i += 1) {
+        try testing.expect(!(try bmp.isSet(@truncate(@TypeOf(bmp).IndexType, i))));
     }
 }
 
-test "Comptime indexToBit" {
-    const Type = ComptimeBitmap(u8);
+test "static indexToBit" {
+    const Type = Bitmap(true, u8, 8);
     try testing.expectEqual(Type.indexToBit(0), 1);
     try testing.expectEqual(Type.indexToBit(1), 2);
     try testing.expectEqual(Type.indexToBit(2), 4);
@@ -565,45 +414,73 @@ test "Comptime indexToBit" {
     try testing.expectEqual(Type.indexToBit(7), 128);
 }
 
-test "Comptime setContiguous" {
-    var bmp = ComptimeBitmap(u16).init();
+test "static setContiguous" {
+    var bmp = try Bitmap(true, u16, 16).init(null, null);
+    try testing.expectEqual(@as(u32, 1), bmp.bitmaps.len);
     // Test trying to set more entries than the bitmap has
     try testing.expectEqual(bmp.setContiguous(bmp.num_free_entries + 1, null), null);
     try testing.expectEqual(bmp.setContiguous(bmp.num_free_entries + 1, 1), null);
     // All entries should still be free
     try testing.expectEqual(bmp.num_free_entries, 16);
-    try testing.expectEqual(bmp.bitmap, 0b0000000000000000);
+    for (bmp.bitmaps) |b| {
+        try expectEqual(b, 0);
+    }
 
     try testing.expectEqual(bmp.setContiguous(3, 0) orelse unreachable, 0);
-    try testing.expectEqual(bmp.bitmap, 0b0000000000000111);
+    try expectEqual(bmp.bitmaps[0], 0b0000000000000111);
+    for (bmp.bitmaps) |b, i| {
+        if (i > 0) try expectEqual(b, 0);
+    }
 
     // Test setting from top
     try testing.expectEqual(bmp.setContiguous(2, 14) orelse unreachable, 14);
-    try testing.expectEqual(bmp.bitmap, 0b1100000000000111);
+    try expectEqual(bmp.bitmaps[0], 0b1100000000000111);
+    for (bmp.bitmaps) |b, i| {
+        if (i > 0) try expectEqual(b, 0);
+    }
 
     try testing.expectEqual(bmp.setContiguous(3, 12), null);
-    try testing.expectEqual(bmp.bitmap, 0b1100000000000111);
+    try expectEqual(bmp.bitmaps[0], 0b1100000000000111);
+    for (bmp.bitmaps) |b, i| {
+        if (i > 0) try expectEqual(b, 0);
+    }
 
     try testing.expectEqual(bmp.setContiguous(3, null) orelse unreachable, 3);
-    try testing.expectEqual(bmp.bitmap, 0b1100000000111111);
+    try expectEqual(bmp.bitmaps[0], 0b1100000000111111);
+    for (bmp.bitmaps) |b, i| {
+        if (i > 0) try expectEqual(b, 0);
+    }
 
     // Test setting beyond the what is available
     try testing.expectEqual(bmp.setContiguous(9, null), null);
-    try testing.expectEqual(bmp.bitmap, 0b1100000000111111);
+    try expectEqual(bmp.bitmaps[0], 0b1100000000111111);
+    for (bmp.bitmaps) |b, i| {
+        if (i > 0) try expectEqual(b, 0);
+    }
 
     try testing.expectEqual(bmp.setContiguous(8, null) orelse unreachable, 6);
-    try testing.expectEqual(bmp.bitmap, 0b1111111111111111);
+    try expectEqual(bmp.bitmaps[0], 0b1111111111111111);
+    for (bmp.bitmaps) |b, i| {
+        if (i > 0) try expectEqual(b, 0);
+    }
 
     // No more are possible
     try testing.expectEqual(bmp.setContiguous(1, null), null);
-    try testing.expectEqual(bmp.bitmap, 0b1111111111111111);
+    try expectEqual(bmp.bitmaps[0], 0b1111111111111111);
+    for (bmp.bitmaps) |b, i| {
+        if (i > 0) try expectEqual(b, 0);
+    }
 
     try testing.expectEqual(bmp.setContiguous(1, 0), null);
-    try testing.expectEqual(bmp.bitmap, 0b1111111111111111);
+    try expectEqual(bmp.bitmaps[0], 0b1111111111111111);
+    for (bmp.bitmaps) |b, i| {
+        if (i > 0) try expectEqual(b, 0);
+    }
 }
 
 test "setEntry" {
-    var bmp = try Bitmap(u32).init(31, std.testing.allocator);
+    var bmp = try Bitmap(false, u32, null).init(31, std.testing.allocator);
+    try testing.expectEqual(@as(u32, 1), bmp.bitmaps.len);
     defer bmp.deinit();
     try testing.expectEqual(@as(u32, 31), bmp.num_free_entries);
 
@@ -620,12 +497,13 @@ test "setEntry" {
     try testing.expectEqual(@as(u32, 3), bmp.bitmaps[0]);
     try testing.expectEqual(@as(u32, 29), bmp.num_free_entries);
 
-    try testing.expectError(Bitmap(u32).BitmapError.OutOfBounds, bmp.setEntry(31));
+    try testing.expectError(BitmapError.OutOfBounds, bmp.setEntry(31));
     try testing.expectEqual(@as(u32, 29), bmp.num_free_entries);
 }
 
 test "clearEntry" {
-    var bmp = try Bitmap(u32).init(32, std.testing.allocator);
+    var bmp = try Bitmap(false, u32, null).init(32, std.testing.allocator);
+    try testing.expectEqual(@as(u32, 1), bmp.bitmaps.len);
     defer bmp.deinit();
     try testing.expectEqual(@as(u32, 32), bmp.num_free_entries);
 
@@ -648,11 +526,12 @@ test "clearEntry" {
     try testing.expectEqual(@as(u32, 31), bmp.num_free_entries);
     try testing.expectEqual(@as(u32, 2), bmp.bitmaps[0]);
 
-    try testing.expectError(Bitmap(u32).BitmapError.OutOfBounds, bmp.clearEntry(32));
+    try testing.expectError(BitmapError.OutOfBounds, bmp.clearEntry(32));
 }
 
 test "setFirstFree multiple bitmaps" {
-    var bmp = try Bitmap(u8).init(9, std.testing.allocator);
+    var bmp = try Bitmap(false, u8, null).init(9, std.testing.allocator);
+    try testing.expectEqual(@as(u32, 2), bmp.bitmaps.len);
     defer bmp.deinit();
 
     // Allocate the first entry
@@ -666,10 +545,10 @@ test "setFirstFree multiple bitmaps" {
     // Allocate the entirety of the first bitmap
     var entry: u32 = 2;
     var expected: u8 = 7;
-    while (entry < Bitmap(u8).ENTRIES_PER_BITMAP) {
+    while (entry < @TypeOf(bmp).ENTRIES_PER_BITMAP) {
         try testing.expectEqual(bmp.setFirstFree() orelse unreachable, entry);
         try testing.expectEqual(bmp.bitmaps[0], expected);
-        if (entry + 1 < Bitmap(u8).ENTRIES_PER_BITMAP) {
+        if (entry + 1 < @TypeOf(bmp).ENTRIES_PER_BITMAP) {
             entry += 1;
             expected = expected * 2 + 1;
         } else {
@@ -678,18 +557,19 @@ test "setFirstFree multiple bitmaps" {
     }
 
     // Try allocating an entry in the next bitmap
-    try testing.expectEqual(bmp.setFirstFree() orelse unreachable, Bitmap(u8).ENTRIES_PER_BITMAP);
-    try testing.expectEqual(bmp.bitmaps[0], Bitmap(u8).BITMAP_FULL);
+    try testing.expectEqual(bmp.setFirstFree() orelse unreachable, @TypeOf(bmp).ENTRIES_PER_BITMAP);
+    try testing.expectEqual(bmp.bitmaps[0], @TypeOf(bmp).BITMAP_FULL);
     try testing.expectEqual(bmp.bitmaps[1], 1);
 
     // We should no longer be able to allocate any entries
     try testing.expectEqual(bmp.setFirstFree(), null);
-    try testing.expectEqual(bmp.bitmaps[0], Bitmap(u8).BITMAP_FULL);
+    try testing.expectEqual(bmp.bitmaps[0], @TypeOf(bmp).BITMAP_FULL);
     try testing.expectEqual(bmp.bitmaps[1], 1);
 }
 
 test "setFirstFree" {
-    var bmp = try Bitmap(u32).init(32, std.testing.allocator);
+    var bmp = try Bitmap(false, u32, null).init(32, std.testing.allocator);
+    try testing.expectEqual(@as(u32, 1), bmp.bitmaps.len);
     defer bmp.deinit();
 
     // Allocate the first entry
@@ -701,17 +581,18 @@ test "setFirstFree" {
     try testing.expectEqual(bmp.bitmaps[0], 3);
 
     // Make all but the MSB occupied and try to allocate it
-    bmp.bitmaps[0] = Bitmap(u32).BITMAP_FULL & ~@as(u32, 1 << (Bitmap(u32).ENTRIES_PER_BITMAP - 1));
-    try testing.expectEqual(bmp.setFirstFree() orelse unreachable, Bitmap(u32).ENTRIES_PER_BITMAP - 1);
-    try testing.expectEqual(bmp.bitmaps[0], Bitmap(u32).BITMAP_FULL);
+    bmp.bitmaps[0] = @TypeOf(bmp).BITMAP_FULL & ~@as(u32, 1 << (@TypeOf(bmp).ENTRIES_PER_BITMAP - 1));
+    try testing.expectEqual(bmp.setFirstFree() orelse unreachable, @TypeOf(bmp).ENTRIES_PER_BITMAP - 1);
+    try testing.expectEqual(bmp.bitmaps[0], @TypeOf(bmp).BITMAP_FULL);
 
     // We should no longer be able to allocate any entries
     try testing.expectEqual(bmp.setFirstFree(), null);
-    try testing.expectEqual(bmp.bitmaps[0], Bitmap(u32).BITMAP_FULL);
+    try testing.expectEqual(bmp.bitmaps[0], @TypeOf(bmp).BITMAP_FULL);
 }
 
 test "isSet" {
-    var bmp = try Bitmap(u32).init(32, std.testing.allocator);
+    var bmp = try Bitmap(false, u32, null).init(32, std.testing.allocator);
+    try testing.expectEqual(@as(u32, 1), bmp.bitmaps.len);
     defer bmp.deinit();
 
     bmp.bitmaps[0] = 1;
@@ -740,12 +621,13 @@ test "isSet" {
         try testing.expect(!try bmp.isSet(i));
     }
 
-    try testing.expectError(Bitmap(u32).BitmapError.OutOfBounds, bmp.isSet(33));
+    try testing.expectError(BitmapError.OutOfBounds, bmp.isSet(33));
 }
 
 test "indexToBit" {
-    const Type = Bitmap(u8);
+    const Type = Bitmap(false, u8, null);
     var bmp = try Type.init(10, std.testing.allocator);
+    try testing.expectEqual(@as(u32, 2), bmp.bitmaps.len);
     defer bmp.deinit();
     try testing.expectEqual(Type.indexToBit(0), 1);
     try testing.expectEqual(Type.indexToBit(1), 2);
@@ -759,7 +641,7 @@ test "indexToBit" {
     try testing.expectEqual(Type.indexToBit(9), 2);
 }
 
-fn testCheckBitmaps(bmp: Bitmap(u4), b1: u4, b2: u4, b3: u4, b4: u4) !void {
+fn testCheckBitmaps(bmp: Bitmap(false, u4, null), b1: u4, b2: u4, b3: u4, b4: u4) !void {
     try testing.expectEqual(@as(u4, b1), bmp.bitmaps[0]);
     try testing.expectEqual(@as(u4, b2), bmp.bitmaps[1]);
     try testing.expectEqual(@as(u4, b3), bmp.bitmaps[2]);
@@ -767,7 +649,8 @@ fn testCheckBitmaps(bmp: Bitmap(u4), b1: u4, b2: u4, b3: u4, b4: u4) !void {
 }
 
 test "setContiguous" {
-    var bmp = try Bitmap(u4).init(16, std.testing.allocator);
+    var bmp = try Bitmap(false, u4, null).init(16, std.testing.allocator);
+    try testing.expectEqual(@as(u32, 4), bmp.bitmaps.len);
     defer bmp.deinit();
     // Test trying to set more entries than the bitmap has
     try testing.expectEqual(bmp.setContiguous(bmp.num_entries + 1, null), null);

--- a/src/kernel/filesystem/vfs.zig
+++ b/src/kernel/filesystem/vfs.zig
@@ -4,6 +4,8 @@ const TailQueue = std.TailQueue;
 const ArrayList = std.ArrayList;
 const Allocator = std.mem.Allocator;
 
+pub const Handle = usize;
+
 /// Flags specifying what to do when opening a file or directory
 pub const OpenFlags = enum {
     /// Create a directory if it doesn't exist

--- a/src/kernel/filesystem/vfs.zig
+++ b/src/kernel/filesystem/vfs.zig
@@ -284,7 +284,7 @@ pub const MountError = error{
 pub const SEPARATOR: u8 = '/';
 
 /// The root of the system's top-level filesystem
-pub var root: *Node = undefined;
+var root: *Node = undefined;
 
 ///
 /// Traverse the specified path from the root and open the file/dir corresponding to that path. If the file/dir doesn't exist it can be created by specifying the open flags

--- a/src/kernel/filesystem/vfs.zig
+++ b/src/kernel/filesystem/vfs.zig
@@ -422,6 +422,20 @@ pub fn open(path: []const u8, follow_symlinks: bool, flags: OpenFlags, args: Ope
 }
 
 ///
+/// Close a node.
+///
+/// Arguments:
+///     IN node: Node - The node to close
+///
+pub fn close(node: Node) void {
+    switch (node) {
+        .Dir => |d| d.close(),
+        .File => |f| f.close(),
+        .Symlink => |s| s.close(),
+    }
+}
+
+///
 /// Open a file at a path.
 ///
 /// Arguments:

--- a/src/kernel/kmain.zig
+++ b/src/kernel/kmain.zig
@@ -17,6 +17,7 @@ const scheduler = @import("scheduler.zig");
 const vfs = @import("filesystem/vfs.zig");
 const initrd = @import("filesystem/initrd.zig");
 const keyboard = @import("keyboard.zig");
+const syscalls = @import("syscalls.zig");
 const Allocator = std.mem.Allocator;
 
 comptime {
@@ -96,6 +97,7 @@ export fn kmain(boot_payload: arch.BootPayload) void {
         panic_root.panic(@errorReturnTrace(), "Failed to initialise kernel heap: {}\n", .{e});
     };
 
+    syscalls.init(&kernel_heap.allocator);
     tty.init(kernel_heap.allocator(), boot_payload);
     var arch_kb = keyboard.init(fixed_allocator.allocator()) catch |e| {
         panic_root.panic(@errorReturnTrace(), "Failed to inititalise keyboard: {}\n", .{e});

--- a/src/kernel/kmain.zig
+++ b/src/kernel/kmain.zig
@@ -97,7 +97,7 @@ export fn kmain(boot_payload: arch.BootPayload) void {
         panic_root.panic(@errorReturnTrace(), "Failed to initialise kernel heap: {}\n", .{e});
     };
 
-    syscalls.init(&kernel_heap.allocator);
+    syscalls.init(kernel_heap.allocator());
     tty.init(kernel_heap.allocator(), boot_payload);
     var arch_kb = keyboard.init(fixed_allocator.allocator()) catch |e| {
         panic_root.panic(@errorReturnTrace(), "Failed to inititalise keyboard: {}\n", .{e});

--- a/src/kernel/pmm.zig
+++ b/src/kernel/pmm.zig
@@ -6,10 +6,11 @@ const arch = @import("arch.zig").internals;
 const MemProfile = @import("mem.zig").MemProfile;
 const testing = std.testing;
 const panic = @import("panic.zig").panic;
-const Bitmap = @import("bitmap.zig").Bitmap;
+const bitmap = @import("bitmap.zig");
+const Bitmap = bitmap.Bitmap;
 const Allocator = std.mem.Allocator;
 
-const PmmBitmap = Bitmap(u32);
+const PmmBitmap = Bitmap(false, u32, null);
 
 /// The possible errors thrown by bitmap functions
 const PmmError = error{
@@ -20,7 +21,7 @@ const PmmError = error{
 /// The size of memory associated with each bitmap entry
 pub const BLOCK_SIZE: usize = arch.MEMORY_BLOCK_SIZE;
 
-var bitmap: PmmBitmap = undefined;
+var the_bitmap: PmmBitmap = undefined;
 
 ///
 /// Set the bitmap entry for an address as occupied
@@ -31,8 +32,8 @@ var bitmap: PmmBitmap = undefined;
 /// Error: PmmBitmap.BitmapError.
 ///     *: See PmmBitmap.setEntry. Could occur if the address is out of bounds.
 ///
-pub fn setAddr(addr: usize) PmmBitmap.BitmapError!void {
-    try bitmap.setEntry(@intCast(u32, addr / BLOCK_SIZE));
+pub fn setAddr(addr: usize) bitmap.BitmapError!void {
+    try the_bitmap.setEntry(@intCast(u32, addr / BLOCK_SIZE));
 }
 
 ///
@@ -46,8 +47,8 @@ pub fn setAddr(addr: usize) PmmBitmap.BitmapError!void {
 /// Error: PmmBitmap.BitmapError.
 ///     *: See PmmBitmap.setEntry. Could occur if the address is out of bounds.
 ///
-pub fn isSet(addr: usize) PmmBitmap.BitmapError!bool {
-    return bitmap.isSet(@intCast(u32, addr / BLOCK_SIZE));
+pub fn isSet(addr: usize) bitmap.BitmapError!bool {
+    return the_bitmap.isSet(@intCast(u32, addr / BLOCK_SIZE));
 }
 
 ///
@@ -56,7 +57,7 @@ pub fn isSet(addr: usize) PmmBitmap.BitmapError!bool {
 /// Return: The address that was allocated.
 ///
 pub fn alloc() ?usize {
-    if (bitmap.setFirstFree()) |entry| {
+    if (the_bitmap.setFirstFree()) |entry| {
         return entry * BLOCK_SIZE;
     }
     return null;
@@ -72,10 +73,10 @@ pub fn alloc() ?usize {
 ///     PmmError.NotAllocated: The address wasn't allocated.
 ///     PmmBitmap.BitmapError.OutOfBounds: The address given was out of bounds.
 ///
-pub fn free(addr: usize) (PmmBitmap.BitmapError || PmmError)!void {
+pub fn free(addr: usize) (bitmap.BitmapError || PmmError)!void {
     const idx = @intCast(u32, addr / BLOCK_SIZE);
-    if (try bitmap.isSet(idx)) {
-        try bitmap.clearEntry(idx);
+    if (try the_bitmap.isSet(idx)) {
+        try the_bitmap.clearEntry(idx);
     } else {
         return PmmError.NotAllocated;
     }
@@ -88,7 +89,7 @@ pub fn free(addr: usize) (PmmBitmap.BitmapError || PmmError)!void {
 ///     The number of unallocated blocks of memory
 ///
 pub fn blocksFree() usize {
-    return bitmap.num_free_entries;
+    return the_bitmap.num_free_entries;
 }
 
 /// Intiialise the physical memory manager and set all unavailable regions as occupied (those from the memory map and those from the linker symbols).
@@ -101,7 +102,7 @@ pub fn init(mem_profile: *const MemProfile, allocator: Allocator) void {
     log.info("Init\n", .{});
     defer log.info("Done\n", .{});
 
-    bitmap = PmmBitmap.init(mem_profile.mem_kb * 1024 / BLOCK_SIZE, allocator) catch |e| {
+    the_bitmap = PmmBitmap.init(mem_profile.mem_kb * 1024 / BLOCK_SIZE, allocator) catch |e| {
         panic(@errorReturnTrace(), "Bitmap allocation failed: {}\n", .{e});
     };
 
@@ -116,7 +117,7 @@ pub fn init(mem_profile: *const MemProfile, allocator: Allocator) void {
         while (addr < end) : (addr += BLOCK_SIZE) {
             setAddr(addr) catch |e| switch (e) {
                 // We can ignore out of bounds errors as the memory won't be available anyway
-                PmmBitmap.BitmapError.OutOfBounds => break,
+                bitmap.BitmapError.OutOfBounds => break,
                 else => panic(@errorReturnTrace(), "Failed setting address 0x{x} from memory map as occupied: {}", .{ addr, e }),
             };
         }
@@ -132,12 +133,12 @@ pub fn init(mem_profile: *const MemProfile, allocator: Allocator) void {
 /// Free the internal state of the PMM. Is unusable aftwards unless re-initialised
 ///
 pub fn deinit() void {
-    bitmap.deinit();
+    the_bitmap.deinit();
 }
 
 test "alloc" {
-    bitmap = try Bitmap(u32).init(32, testing.allocator);
-    defer bitmap.deinit();
+    the_bitmap = try Bitmap(false, u32, null).init(32, testing.allocator);
+    defer the_bitmap.deinit();
     comptime var addr = 0;
     comptime var i = 0;
     // Allocate all entries, making sure they succeed and return the correct addresses
@@ -155,8 +156,8 @@ test "alloc" {
 }
 
 test "free" {
-    bitmap = try Bitmap(u32).init(32, testing.allocator);
-    defer bitmap.deinit();
+    the_bitmap = try Bitmap(false, u32, null).init(32, testing.allocator);
+    defer the_bitmap.deinit();
     comptime var i = 0;
     // Allocate and free all entries
     inline while (i < 32) : (i += 1) {
@@ -173,8 +174,8 @@ test "free" {
 
 test "setAddr and isSet" {
     const num_entries: u32 = 32;
-    bitmap = try Bitmap(u32).init(num_entries, testing.allocator);
-    defer bitmap.deinit();
+    the_bitmap = try Bitmap(false, u32, null).init(num_entries, testing.allocator);
+    defer the_bitmap.deinit();
     var addr: u32 = 0;
     var i: u32 = 0;
     while (i < num_entries) : ({

--- a/src/kernel/scheduler.zig
+++ b/src/kernel/scheduler.zig
@@ -27,7 +27,7 @@ extern var KERNEL_STACK_START: []u32;
 extern var KERNEL_STACK_END: []u32;
 
 /// The current task running
-var current_task: *Task = undefined;
+pub var current_task: *Task = undefined;
 
 /// Array list of all runnable tasks
 var tasks: TailQueue(*Task) = undefined;

--- a/src/kernel/scheduler.zig
+++ b/src/kernel/scheduler.zig
@@ -14,6 +14,7 @@ const mem = @import("mem.zig");
 const fs = @import("filesystem/vfs.zig");
 const elf = @import("elf.zig");
 const pmm = @import("pmm.zig");
+const bitmap = @import("bitmap.zig");
 const Task = task.Task;
 const EntryPoint = task.EntryPoint;
 const Allocator = std.mem.Allocator;
@@ -146,6 +147,9 @@ pub fn init(allocator: Allocator, mem_profile: *const mem.MemProfile) Allocator.
     current_task.kernel_stack = @intToPtr([*]u32, @ptrToInt(&KERNEL_STACK_START))[0..kernel_stack_size];
     current_task.user_stack = &[_]usize{};
     current_task.kernel = true;
+    // TODO: Use Task.create instead of setting it up manually
+    current_task.file_handles = try bitmap.Bitmap(usize).init(task.VFS_HANDLES_PER_PROCESS, allocator);
+    current_task.file_handle_mapping = std.hash_map.AutoHashMap(task.Handle, *fs.Node).init(allocator);
     // ESP will be saved on next schedule
 
     // Run the runtime tests here

--- a/src/kernel/syscalls.zig
+++ b/src/kernel/syscalls.zig
@@ -211,17 +211,29 @@ fn getData(ptr: usize, len: usize) Error![]u8 {
     }
 }
 
-fn handleOpen(path_ptr: usize, path_len: usize, flags: usize, ignored1: usize, ignored2: usize) Error!usize {
+fn handleOpen(path_ptr: usize, path_len: usize, flags: usize, args: usize, ignored: usize) Error!usize {
     const current_task = scheduler.current_task;
     if (!current_task.hasFreeVFSHandle()) {
         return Error.NoMoreFSHandles;
     }
 
+    // Fetch the open arguments from user/kernel memory
+    var open_args: vfs.OpenArgs = if (args == 0) .{} else blk: {
+        const data = try getData(args, @sizeOf(vfs.OpenArgs));
+        defer if (!current_task.kernel) allocator.free(data);
+        break :blk std.mem.bytesAsValue(vfs.OpenArgs, data[0..@sizeOf(vfs.OpenArgs)]).*;
+    };
+    // The symlink target could refer to a location in user memory so convert that too
+    if (open_args.symlink_target) |target| {
+        open_args.symlink_target = try getData(@ptrToInt(target.ptr), target.len);
+    }
+    defer if (!current_task.kernel) if (open_args.symlink_target) |target| allocator.free(target);
+
     const open_flags = std.meta.intToEnum(vfs.OpenFlags, flags) catch return Error.InvalidFlags;
     const path = try getData(path_ptr, path_len);
     defer if (!current_task.kernel) allocator.free(path);
 
-    var node = try vfs.open(path, true, open_flags, .{});
+    var node = try vfs.open(path, true, open_flags, open_args);
     return current_task.addVFSHandle(node) orelse panic(null, "Failed to add a VFS handle to current_task\n", .{});
 }
 
@@ -426,5 +438,12 @@ test "handleRead" {
     {
         const length = try handleRead(test_file, @ptrToInt(&buffer[0]), 0, undefined, undefined);
         testing.expect(std.mem.eql(u8, str[0..0], buffer[0..length]));
+    }
+    // Try reading from a symlink
+    const args = vfs.OpenArgs{ .symlink_target = "/foo.txt" };
+    var test_link = try handleOpen(@ptrToInt("/link"), "/link".len, @enumToInt(vfs.OpenFlags.CREATE_SYMLINK), @ptrToInt(&args), undefined);
+    {
+        const length = try handleRead(test_link, @ptrToInt(&buffer[0]), buffer.len, undefined, undefined);
+        testing.expect(std.mem.eql(u8, str[0..str.len], buffer[0..length]));
     }
 }

--- a/src/kernel/syscalls.zig
+++ b/src/kernel/syscalls.zig
@@ -78,12 +78,12 @@ pub fn init(alloc: *std.mem.Allocator) void {
 /// Passing an error code that does not correspond to an error results in safety-protected undefined behaviour
 ///
 /// Arguments:
-///     IN code: usize - The erorr code to convert
+///     IN code: u16 - The erorr code to convert
 ///
 /// Return: Error
 ///     The error corresponding to the error code
 ///
-pub fn fromErrorCode(code: usize) Error {
+pub fn fromErrorCode(code: u16) anyerror {
     return @intToError(code);
 }
 
@@ -93,10 +93,10 @@ pub fn fromErrorCode(code: usize) Error {
 /// Arguments:
 ///     IN err: Error - The erorr to convert
 ///
-/// Return: usize
+/// Return: u16
 ///     The error code corresponding to the error
 ///
-pub fn toErrorCode(err: Error) usize {
+pub fn toErrorCode(err: anyerror) u16 {
     return @errorToInt(err);
 }
 

--- a/src/kernel/syscalls.zig
+++ b/src/kernel/syscalls.zig
@@ -220,8 +220,7 @@ fn handleWrite(node_handle: usize, buff_ptr: usize, buff_len: usize, ignored1: u
 
         // TODO: A more performant method would be mapping in the user memory and using that directly. Then we wouldn't need to allocate or copy the buffer
         if (!current_task.kernel) try vmm.kernel_vmm.copyData(current_task.vmm, buff, buff_ptr, false);
-        const bytes_read = try file.read(buff);
-        return bytes_read;
+        return try file.write(buff);
     }
 
     return Error.NotOpened;
@@ -234,7 +233,6 @@ fn handleClose(node_handle: usize, ignored1: usize, ignored2: usize, ignored3: u
     const current_task = scheduler.current_task;
     const node_opt = current_task.getVFSHandle(real_handle) catch panic(@errorReturnTrace(), "Failed to get VFS node for handle {}\n", .{real_handle});
     if (node_opt) |node| {
-        //try node.close();
         current_task.clearVFSHandle(real_handle) catch |e| return switch (e) {
             error.VFSHandleNotSet, error.OutOfBounds => Error.NotOpened,
         };

--- a/src/kernel/syscalls.zig
+++ b/src/kernel/syscalls.zig
@@ -1,44 +1,47 @@
 const std = @import("std");
+const is_test = @import("builtin").is_test;
 const scheduler = @import("scheduler.zig");
 const panic = @import("panic.zig").panic;
 const log = std.log.scoped(.syscalls);
+const vfs = @import("filesystem/vfs.zig");
+const vmm = @import("vmm.zig");
+const bitmap = @import("bitmap.zig");
+const task = @import("task.zig");
+const arch = @import("arch.zig").internals;
+const testing = std.testing;
+
+var allocator: *std.mem.Allocator = undefined;
+
+/// The maximum amount of data to allocate when copying user memory into kernel memory
+pub const USER_MAX_DATA_LEN = 16 * 1024;
 
 /// A compilation of all errors that syscall handlers could return.
-pub const Error = error{OutOfMemory};
-
-///
-/// Convert an error code to an instance of Error. The conversion must be synchronised with toErrorCode
-///
-/// Arguments:
-///     IN code: usize - The erorr code to convert
-///
-/// Return: Error
-///     The error corresponding to the error code
-///
-pub fn fromErrorCode(code: usize) Error {
-    return switch (code) {
-        1 => Error.OutOfMemory,
-        else => unreachable,
-    };
-}
-
-///
-/// Convert an instance of Error to an error code. The conversion must be synchronised with fromErrorCode
-///
-/// Arguments:
-///     IN err: Error - The erorr to convert
-///
-/// Return: usize
-///     The error code corresponding to the error
-///
-pub fn toErrorCode(err: Error) usize {
-    return switch (err) {
-        Error.OutOfMemory => 1,
-    };
-}
+pub const Error = error{
+    OutOfMemory,
+    NoMoreFSHandles,
+    InvalidFlags,
+    TooBig,
+    NoSuchFileOrDir,
+    NotADirectory,
+    IsADirectory,
+    IsAFile,
+    NotAFile,
+    NotAbsolutePath,
+    NotOpened,
+    NoSymlinkTarget,
+    OutOfBounds,
+    NotAllocated,
+    AlreadyAllocated,
+    PhysicalAlreadyAllocated,
+    PhysicalVirtualMismatch,
+    InvalidVirtAddresses,
+    InvalidPhysAddresses,
+    Unexpected,
+};
 
 comptime {
     // Make sure toErrorCode and fromErrorCode are synchronised, and that no errors share the same error code
+    @setEvalBranchQuota(1000000);
     inline for (@typeInfo(Error).ErrorSet.?) |err| {
         const error_instance = @field(Error, err.name);
         if (fromErrorCode(toErrorCode(error_instance)) != error_instance) {
@@ -55,6 +58,10 @@ comptime {
 
 /// All implemented syscalls
 pub const Syscall = enum {
+    Open,
+    Read,
+    Write,
+    Close,
     Test1,
     Test2,
     Test3,
@@ -70,6 +77,10 @@ pub const Syscall = enum {
     ///
     fn getHandler(self: @This()) Handler {
         return switch (self) {
+            .Open => handleOpen,
+            .Read => handleRead,
+            .Write => handleWrite,
+            .Close => handleClose,
             .Test1 => handleTest1,
             .Test2 => handleTest2,
             .Test3 => handleTest3,
@@ -79,6 +90,79 @@ pub const Syscall = enum {
 
 /// A function that can handle a syscall and return a result or an error
 pub const Handler = fn (arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) Error!usize;
+
+pub fn init(alloc: *std.mem.Allocator) void {
+    allocator = alloc;
+}
+
+///
+/// Convert an error code to an instance of Error. The conversion must be synchronised with toErrorCode
+///
+/// Arguments:
+///     IN code: usize - The erorr code to convert
+///
+/// Return: Error
+///     The error corresponding to the error code
+///
+pub fn fromErrorCode(code: usize) Error {
+    return switch (code) {
+        1 => Error.OutOfMemory,
+        2 => Error.NoMoreFSHandles,
+        3 => Error.InvalidFlags,
+        4 => Error.TooBig,
+        5 => Error.NoSuchFileOrDir,
+        6 => Error.NotADirectory,
+        7 => Error.IsADirectory,
+        8 => Error.IsAFile,
+        9 => Error.NotAbsolutePath,
+        10 => Error.NotOpened,
+        11 => Error.NoSymlinkTarget,
+        12 => Error.OutOfBounds,
+        13 => Error.NotAllocated,
+        14 => Error.NotAFile,
+        15 => Error.AlreadyAllocated,
+        16 => Error.PhysicalAlreadyAllocated,
+        17 => Error.PhysicalVirtualMismatch,
+        18 => Error.InvalidVirtAddresses,
+        19 => Error.InvalidPhysAddresses,
+        20 => Error.Unexpected,
+        else => unreachable,
+    };
+}
+
+///
+/// Convert an instance of Error to an error code. The conversion must be synchronised with fromErrorCode
+///
+/// Arguments:
+///     IN err: Error - The erorr to convert
+///
+/// Return: usize
+///     The error code corresponding to the error
+///
+pub fn toErrorCode(err: Error) usize {
+    return switch (err) {
+        Error.OutOfMemory => 1,
+        Error.NoMoreFSHandles => 2,
+        Error.InvalidFlags => 3,
+        Error.TooBig => 4,
+        Error.NoSuchFileOrDir => 5,
+        Error.NotADirectory => 6,
+        Error.IsADirectory => 7,
+        Error.IsAFile => 8,
+        Error.NotAbsolutePath => 9,
+        Error.NotOpened => 10,
+        Error.NoSymlinkTarget => 11,
+        Error.OutOfBounds => 12,
+        Error.NotAllocated => 13,
+        Error.NotAFile => 14,
+        Error.AlreadyAllocated => 15,
+        Error.PhysicalAlreadyAllocated => 16,
+        Error.PhysicalVirtualMismatch => 17,
+        Error.InvalidVirtAddresses => 18,
+        Error.InvalidPhysAddresses => 19,
+        Error.Unexpected => 20,
+    };
+}
 
 ///
 /// Handle a syscall and return a result or error
@@ -95,6 +179,110 @@ pub const Handler = fn (arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5
 ///
 pub fn handle(syscall: Syscall, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) Error!usize {
     return try syscall.getHandler()(arg1, arg2, arg3, arg4, arg5);
+}
+
+///
+/// Get a slice containing the data at an address and length. If the current task is a kernel task then a simple pointer to slice conversion is performed,
+/// otherwise the slice is allocated on the heap and the data is copied in from user space.
+///
+/// Arguments:
+///     IN ptr: usize - The slice's address
+///     IN len: usize - The number of bytes
+///
+/// Error: Error
+///     Error.OutOfMemory - There wasn't enough kernel (heap or VMM) memory left to fulfill the request.
+///     Error.TooBig - The user task requested to have too much data copied
+///     Error.InvalidAddress - The address that the user task passed is invalid (not mapped, out of bounds etc.)
+///
+/// Return: []u8
+///     The slice of data. Will be stack-allocated if the current task is kernel-level, otherwise will be heap-allocated
+///
+fn getData(ptr: usize, len: usize) Error![]u8 {
+    if (scheduler.current_task.kernel) {
+        return @intToPtr([*]u8, ptr)[0..len];
+    } else {
+        if (len > USER_MAX_DATA_LEN) {
+            return Error.TooBig;
+        }
+        var buff = try allocator.alloc(u8, len);
+        errdefer allocator.free(buff);
+        try vmm.kernel_vmm.copyData(scheduler.current_task.vmm, buff, ptr, false);
+        return buff;
+    }
+}
+
+fn handleOpen(path_ptr: usize, path_len: usize, flags: usize, ignored1: usize, ignored2: usize) Error!usize {
+    const current_task = scheduler.current_task;
+    if (!current_task.hasFreeVFSHandle()) {
+        return Error.NoMoreFSHandles;
+    }
+
+    const open_flags = std.meta.intToEnum(vfs.OpenFlags, flags) catch return Error.InvalidFlags;
+    const path = try getData(path_ptr, path_len);
+    defer if (!current_task.kernel) allocator.free(path);
+
+    var node = try vfs.open(path, true, open_flags, .{});
+    return current_task.addVFSHandle(node) orelse panic(null, "Failed to add a VFS handle to current_task\n", .{});
+}
+
+fn handleRead(node_handle: usize, buff_ptr: usize, buff_len: usize, ignored1: usize, ignored2: usize) Error!usize {
+    if (buff_len > USER_MAX_DATA_LEN) {
+        return Error.TooBig;
+    }
+
+    const current_task = scheduler.current_task;
+    const node_opt = current_task.getVFSHandle(node_handle) catch panic(@errorReturnTrace(), "Failed to get VFS node for handle {}\n", .{node_handle});
+    if (node_opt) |node| {
+        const file = switch (node.*) {
+            .File => |*f| f,
+            else => return Error.NotAFile,
+        };
+        var buff = if (current_task.kernel) @intToPtr([*]u8, buff_ptr)[0..buff_len] else try allocator.alloc(u8, buff_len);
+        defer if (!current_task.kernel) allocator.free(buff);
+
+        const bytes_read = try file.read(buff);
+        // TODO: A more performant method would be mapping in the user memory and using that directly. Then we wouldn't need to allocate or copy the buffer
+        if (!current_task.kernel) try vmm.kernel_vmm.copyData(current_task.vmm, buff, buff_ptr, true);
+        return bytes_read;
+    }
+
+    return Error.NotOpened;
+}
+
+fn handleWrite(node_handle: usize, buff_ptr: usize, buff_len: usize, ignored1: usize, ignored2: usize) Error!usize {
+    if (buff_len > USER_MAX_DATA_LEN) {
+        return Error.TooBig;
+    }
+
+    const current_task = scheduler.current_task;
+    const node_opt = current_task.getVFSHandle(node_handle) catch panic(@errorReturnTrace(), "Failed to get VFS node for handle {}\n", .{node_handle});
+    if (node_opt) |node| {
+        const file = switch (node.*) {
+            .File => |f| f,
+            else => return Error.NotAFile,
+        };
+        var buff = if (current_task.kernel) @intToPtr([*]u8, buff_ptr)[0..buff_len] else try allocator.alloc(u8, buff_len);
+        defer if (!current_task.kernel) allocator.free(buff);
+
+        // TODO: A more performant method would be mapping in the user memory and using that directly. Then we wouldn't need to allocate or copy the buffer
+        if (!current_task.kernel) try vmm.kernel_vmm.copyData(current_task.vmm, buff, buff_ptr, false);
+        const bytes_read = try file.read(buff);
+        return bytes_read;
+    }
+
+    return Error.NotOpened;
+}
+
+fn handleClose(node_handle: usize, ignored1: usize, ignored2: usize, ignored3: usize, ignored4: usize) Error!usize {
+    const current_task = scheduler.current_task;
+    const node_opt = current_task.getVFSHandle(node_handle) catch panic(@errorReturnTrace(), "Failed to get VFS node for handle {}\n", .{node_handle});
+    if (node_opt) |node| {
+        //try node.close();
+        current_task.clearVFSHandle(node_handle) catch |e| return switch (e) {
+            error.VFSHandleNotSet, error.OutOfBounds => Error.NotOpened,
+        };
+    }
+    return Error.NotOpened;
 }
 
 pub fn handleTest1(arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) Error!usize {
@@ -125,10 +313,118 @@ test "getHandler" {
     try std.testing.expectEqual(Syscall.Test1.getHandler(), handleTest1);
     try std.testing.expectEqual(Syscall.Test2.getHandler(), handleTest2);
     try std.testing.expectEqual(Syscall.Test3.getHandler(), handleTest3);
+    try std.testing.expectEqual(Syscall.Open.getHandler(), handleOpen);
+    try std.testing.expectEqual(Syscall.Close.getHandler(), handleClose);
+    try std.testing.expectEqual(Syscall.Read.getHandler(), handleRead);
+    try std.testing.expectEqual(Syscall.Write.getHandler(), handleWrite);
 }
 
 test "handle" {
     try std.testing.expectEqual(@as(usize, 0), try handle(.Test1, 0, 0, 0, 0, 0));
     try std.testing.expectEqual(@as(usize, 1 + 2 + 3 + 4 + 5), try handle(.Test2, 1, 2, 3, 4, 5));
     try std.testing.expectError(Error.OutOfMemory, handle(.Test3, 0, 0, 0, 0, 0));
+}
+
+test "handleOpen" {
+    allocator = std.testing.allocator;
+    var testfs = try vfs.testInitFs(allocator);
+    defer allocator.destroy(testfs);
+    defer testfs.deinit();
+
+    testfs.instance = 1;
+    vfs.root = testfs.tree.val;
+
+    scheduler.current_task = try task.Task.create(0, true, undefined, allocator);
+    defer scheduler.current_task.destroy(allocator);
+    var current_task = scheduler.current_task;
+
+    // Creating a file
+    const name1 = "/abc.txt";
+    var test_handle = try handleOpen(@ptrToInt(name1), name1.len, @enumToInt(vfs.OpenFlags.CREATE_FILE), undefined, undefined);
+    var test_node = (try current_task.getVFSHandle(test_handle)).?;
+    testing.expectEqual(testfs.tree.children.items.len, 1);
+    var tree = testfs.tree.children.items[0];
+    testing.expect(tree.val.isFile() and test_node.isFile());
+    testing.expectEqual(&test_node.File, &tree.val.File);
+    testing.expect(std.mem.eql(u8, tree.name, "abc.txt"));
+    testing.expectEqual(tree.data, null);
+    testing.expectEqual(tree.children.items.len, 0);
+
+    // Creating a dir
+    const name2 = "/def";
+    test_handle = try handleOpen(@ptrToInt(name2), name2.len, @enumToInt(vfs.OpenFlags.CREATE_DIR), undefined, undefined);
+    test_node = (try current_task.getVFSHandle(test_handle)).?;
+    testing.expectEqual(testfs.tree.children.items.len, 2);
+    tree = testfs.tree.children.items[1];
+    testing.expect(tree.val.isDir() and test_node.isDir());
+    testing.expectEqual(&test_node.Dir, &tree.val.Dir);
+    testing.expect(std.mem.eql(u8, tree.name, "def"));
+    testing.expectEqual(tree.data, null);
+    testing.expectEqual(tree.children.items.len, 0);
+
+    // Creating a file under a new dir
+    const name3 = "/def/ghi.zig";
+    test_handle = try handleOpen(@ptrToInt(name3), name3.len, @enumToInt(vfs.OpenFlags.CREATE_FILE), undefined, undefined);
+    test_node = (try current_task.getVFSHandle(test_handle)).?;
+    testing.expectEqual(testfs.tree.children.items[1].children.items.len, 1);
+    tree = testfs.tree.children.items[1].children.items[0];
+    testing.expect(tree.val.isFile() and test_node.isFile());
+    testing.expectEqual(&test_node.File, &tree.val.File);
+    testing.expect(std.mem.eql(u8, tree.name, "ghi.zig"));
+    testing.expectEqual(tree.data, null);
+    testing.expectEqual(tree.children.items.len, 0);
+
+    // Opening an existing file
+    test_handle = try handleOpen(@ptrToInt(name3), name3.len, @enumToInt(vfs.OpenFlags.NO_CREATION), undefined, undefined);
+    test_node = (try current_task.getVFSHandle(test_handle)).?;
+    testing.expectEqual(testfs.tree.children.items[1].children.items.len, 1);
+    testing.expect(test_node.isFile());
+    testing.expectEqual(&test_node.File, &tree.val.File);
+}
+
+test "handleRead" {
+    allocator = std.testing.allocator;
+    var testfs = try vfs.testInitFs(allocator);
+    defer allocator.destroy(testfs);
+    defer testfs.deinit();
+
+    testfs.instance = 1;
+    vfs.root = testfs.tree.val;
+
+    vmm.kernel_vmm = try vmm.VirtualMemoryManager(arch.VmmPayload).init(0, 1024, allocator, arch.VMM_MAPPER, arch.KERNEL_VMM_PAYLOAD);
+    defer vmm.kernel_vmm.deinit();
+    scheduler.current_task = try task.Task.create(0, true, &vmm.kernel_vmm, allocator);
+    defer scheduler.current_task.destroy(allocator);
+    var current_task = scheduler.current_task;
+
+    var test_file = try handleOpen(@ptrToInt("/foo.txt"), "/foo.txt".len, @enumToInt(vfs.OpenFlags.CREATE_FILE), undefined, undefined);
+    var f_data = &testfs.tree.children.items[0].data;
+    var str = "test123";
+    f_data.* = try std.mem.dupe(testing.allocator, u8, str);
+
+    var buffer: [str.len]u8 = undefined;
+    {
+        const length = try handleRead(test_file, @ptrToInt(&buffer[0]), buffer.len, undefined, undefined);
+        testing.expect(std.mem.eql(u8, str, buffer[0..length]));
+    }
+
+    {
+        const length = try handleRead(test_file, @ptrToInt(&buffer[0]), buffer.len + 1, undefined, undefined);
+        testing.expect(std.mem.eql(u8, str, buffer[0..length]));
+    }
+
+    {
+        const length = try handleRead(test_file, @ptrToInt(&buffer[0]), buffer.len + 3, undefined, undefined);
+        testing.expect(std.mem.eql(u8, str, buffer[0..length]));
+    }
+
+    {
+        const length = try handleRead(test_file, @ptrToInt(&buffer[0]), buffer.len - 1, undefined, undefined);
+        testing.expect(std.mem.eql(u8, str[0 .. str.len - 1], buffer[0..length]));
+    }
+
+    {
+        const length = try handleRead(test_file, @ptrToInt(&buffer[0]), 0, undefined, undefined);
+        testing.expect(std.mem.eql(u8, str[0..0], buffer[0..length]));
+    }
 }

--- a/src/kernel/syscalls.zig
+++ b/src/kernel/syscalls.zig
@@ -48,6 +48,22 @@ pub const Syscall = enum {
             .Test3 => handleTest3,
         };
     }
+
+    ///
+    /// Check if the syscall is just used for testing, and therefore shouldn't be exposed at runtime
+    ///
+    /// Arguments:
+    ///     IN self: Syscall - The syscall to check
+    ///
+    /// Return: bool
+    ///     true if the syscall is only to be used for testing, else false
+    ///
+    pub fn isTest(self: @This()) bool {
+        return switch (self) {
+            .Test1, .Test2, .Test3 => true,
+            else => false,
+        };
+    }
 };
 
 /// A function that can handle a syscall and return a result or an error

--- a/src/kernel/syscalls.zig
+++ b/src/kernel/syscalls.zig
@@ -494,7 +494,8 @@ test "handleRead" {
     defer scheduler.current_task.destroy(allocator);
     var current_task = scheduler.current_task;
 
-    var test_file = @intCast(task.Handle, try handleOpen(@ptrToInt("/foo.txt"), "/foo.txt".len, @enumToInt(vfs.OpenFlags.CREATE_FILE), undefined, undefined));
+    const test_file_path = "/foo.txt";
+    var test_file = @intCast(task.Handle, try handleOpen(@ptrToInt(test_file_path), test_file_path.len, @enumToInt(vfs.OpenFlags.CREATE_FILE), undefined, undefined));
     var f_data = &testfs.tree.children.items[0].data;
     var str = "test123";
     f_data.* = try std.mem.dupe(testing.allocator, u8, str);
@@ -525,7 +526,7 @@ test "handleRead" {
         testing.expect(std.mem.eql(u8, str[0..0], buffer[0..length]));
     }
     // Try reading from a symlink
-    const args = vfs.OpenArgs{ .symlink_target = "/foo.txt" };
+    const args = vfs.OpenArgs{ .symlink_target = test_file_path };
     var test_link = @intCast(task.Handle, try handleOpen(@ptrToInt("/link"), "/link".len, @enumToInt(vfs.OpenFlags.CREATE_SYMLINK), @ptrToInt(&args), undefined));
     {
         const length = try handleRead(test_link, @ptrToInt(&buffer[0]), buffer.len, undefined, undefined);

--- a/src/kernel/syscalls.zig
+++ b/src/kernel/syscalls.zig
@@ -170,7 +170,7 @@ fn handleOpen(path_ptr: usize, path_len: usize, flags: usize, args: usize, ignor
     defer if (!current_task.kernel) allocator.free(path);
 
     var node = try vfs.open(path, true, open_flags, open_args);
-    return current_task.addVFSHandle(node) orelse panic(null, "Failed to add a VFS handle to current_task\n", .{});
+    return (try current_task.addVFSHandle(node)) orelse panic(null, "Failed to add a VFS handle to current_task\n", .{});
 }
 
 fn handleRead(node_handle: usize, buff_ptr: usize, buff_len: usize, ignored1: usize, ignored2: usize) Error!usize {

--- a/src/kernel/syscalls.zig
+++ b/src/kernel/syscalls.zig
@@ -294,7 +294,7 @@ test "handleOpen" {
     defer testfs.deinit();
 
     testfs.instance = 1;
-    vfs.root = testfs.tree.val;
+    try vfs.setRoot(testfs.tree.val);
 
     scheduler.current_task = try task.Task.create(0, true, undefined, allocator);
     defer scheduler.current_task.destroy(allocator);
@@ -351,7 +351,7 @@ test "handleRead" {
     defer testfs.deinit();
 
     testfs.instance = 1;
-    vfs.root = testfs.tree.val;
+    try vfs.setRoot(testfs.tree.val);
 
     vmm.kernel_vmm = try vmm.VirtualMemoryManager(arch.VmmPayload).init(0, 1024, allocator, arch.VMM_MAPPER, arch.KERNEL_VMM_PAYLOAD);
     defer vmm.kernel_vmm.deinit();

--- a/src/kernel/syscalls.zig
+++ b/src/kernel/syscalls.zig
@@ -585,6 +585,48 @@ test "handleRead" {
     }
 }
 
+test "handleRead errors" {
+    allocator = std.testing.allocator;
+    var testfs = try vfs.testInitFs(allocator);
+    {
+        defer allocator.destroy(testfs);
+        defer testfs.deinit();
+
+        testfs.instance = 1;
+        try vfs.setRoot(testfs.tree.val);
+
+        // The data we pass to handleRead needs to be mapped within the VMM, so we need to know their address
+        // Allocating the data within a fixed buffer allocator is the best way to know the address of the data
+        var fixed_buffer_allocator = try testInitMem(3, allocator, true);
+        var buffer_allocator = fixed_buffer_allocator.allocator();
+        defer testDeinitMem(allocator, fixed_buffer_allocator);
+
+        scheduler.current_task = try task.Task.create(0, true, &vmm.kernel_vmm, allocator);
+        defer scheduler.current_task.destroy(allocator);
+
+        // Invalid file handle
+        try testing.expectError(Error.OutOfBounds, handleRead(task.VFS_HANDLES_PER_PROCESS, 0, 0, 0, 0));
+        try testing.expectError(Error.OutOfBounds, handleRead(task.VFS_HANDLES_PER_PROCESS + 1, 0, 0, 0, 0));
+
+        // Unopened file
+        try testing.expectError(Error.NotOpened, handleRead(0, 0, 0, 0, 0));
+        try testing.expectError(Error.NotOpened, handleRead(1, 0, 0, 0, 0));
+        try testing.expectError(Error.NotOpened, handleRead(task.VFS_HANDLES_PER_PROCESS - 1, 0, 0, 0, 0));
+
+        // Reading from a dir
+        const name = try buffer_allocator.dupe(u8, "/dir");
+        const node = try handleOpen(@ptrToInt(name.ptr), name.len, @enumToInt(vfs.OpenFlags.CREATE_DIR), 0, 0);
+        try testing.expectError(Error.NotAFile, handleRead(node, 0, 0, 0, 0));
+
+        // User buffer is too big
+        const name2 = try buffer_allocator.dupe(u8, "/file.txt");
+        const node2 = try handleOpen(@ptrToInt(name2.ptr), name2.len, @enumToInt(vfs.OpenFlags.CREATE_FILE), 0, 0);
+        scheduler.current_task.kernel = false;
+        try testing.expectError(Error.TooBig, handleRead(node2, 0, USER_MAX_DATA_LEN + 1, 0, 0));
+    }
+    try testing.expect(!testing.allocator_instance.detectLeaks());
+}
+
 test "handleWrite" {
     allocator = std.testing.allocator;
     var testfs = try vfs.testInitFs(allocator);

--- a/src/kernel/syscalls.zig
+++ b/src/kernel/syscalls.zig
@@ -16,7 +16,7 @@ var allocator: std.mem.Allocator = undefined;
 pub const USER_MAX_DATA_LEN = 16 * 1024;
 
 /// A compilation of all errors that syscall handlers could return.
-pub const Error = error{ NoMoreFSHandles, TooBig, NotAFile } || std.mem.Allocator.Error || vfs.Error || vmm.VmmError || bitmap.Bitmap(usize).BitmapError;
+pub const Error = error{ NoMoreFSHandles, TooBig, NotAFile } || std.mem.Allocator.Error || vfs.Error || vmm.VmmError || bitmap.BitmapError;
 
 /// All implemented syscalls
 pub const Syscall = enum {

--- a/src/kernel/syscalls.zig
+++ b/src/kernel/syscalls.zig
@@ -259,7 +259,8 @@ fn handleOpen(path_ptr: usize, path_len: usize, flags: usize, args: usize, ignor
     const path = try getData(path_ptr, path_len);
     defer if (!current_task.kernel) allocator.free(path);
 
-    var node = try vfs.open(path, true, open_flags, open_args);
+    const node = try vfs.open(path, true, open_flags, open_args);
+    errdefer vfs.close(node.*);
     return (try current_task.addVFSHandle(node)) orelse panic(null, "Failed to add a VFS handle to current_task\n", .{});
 }
 

--- a/src/kernel/syscalls.zig
+++ b/src/kernel/syscalls.zig
@@ -442,7 +442,7 @@ test "handleOpen" {
 
     // Creating a file
     const name1 = "/abc.txt";
-    var test_handle = @intCast(task.Handle, try handleOpen(@ptrToInt(name1), name1.len, @enumToInt(vfs.OpenFlags.CREATE_FILE), undefined, undefined));
+    var test_handle = @intCast(task.Handle, try handleOpen(@ptrToInt(name1), name1.len, @enumToInt(vfs.OpenFlags.CREATE_FILE), 0, undefined));
     var test_node = (try current_task.getVFSHandle(test_handle)).?;
     try testing.expectEqual(testfs.tree.children.items.len, 1);
     var tree = testfs.tree.children.items[0];
@@ -454,7 +454,7 @@ test "handleOpen" {
 
     // Creating a dir
     const name2 = "/def";
-    test_handle = @intCast(task.Handle, try handleOpen(@ptrToInt(name2), name2.len, @enumToInt(vfs.OpenFlags.CREATE_DIR), undefined, undefined));
+    test_handle = @intCast(task.Handle, try handleOpen(@ptrToInt(name2), name2.len, @enumToInt(vfs.OpenFlags.CREATE_DIR), 0, undefined));
     test_node = (try current_task.getVFSHandle(test_handle)).?;
     try testing.expectEqual(testfs.tree.children.items.len, 2);
     tree = testfs.tree.children.items[1];
@@ -466,7 +466,7 @@ test "handleOpen" {
 
     // Creating a file under a new dir
     const name3 = "/def/ghi.zig";
-    test_handle = @intCast(task.Handle, try handleOpen(@ptrToInt(name3), name3.len, @enumToInt(vfs.OpenFlags.CREATE_FILE), undefined, undefined));
+    test_handle = @intCast(task.Handle, try handleOpen(@ptrToInt(name3), name3.len, @enumToInt(vfs.OpenFlags.CREATE_FILE), 0, undefined));
     test_node = (try current_task.getVFSHandle(test_handle)).?;
     try testing.expectEqual(testfs.tree.children.items[1].children.items.len, 1);
     tree = testfs.tree.children.items[1].children.items[0];
@@ -477,7 +477,7 @@ test "handleOpen" {
     try testing.expectEqual(tree.children.items.len, 0);
 
     // Opening an existing file
-    test_handle = @intCast(task.Handle, try handleOpen(@ptrToInt(name3), name3.len, @enumToInt(vfs.OpenFlags.NO_CREATION), undefined, undefined));
+    test_handle = @intCast(task.Handle, try handleOpen(@ptrToInt(name3), name3.len, @enumToInt(vfs.OpenFlags.NO_CREATION), 0, undefined));
     test_node = (try current_task.getVFSHandle(test_handle)).?;
     try testing.expectEqual(testfs.tree.children.items[1].children.items.len, 1);
     try testing.expect(test_node.isFile());
@@ -500,41 +500,41 @@ test "handleRead" {
     _ = scheduler.current_task;
 
     const test_file_path = "/foo.txt";
-    var test_file = @intCast(task.Handle, try handleOpen(@ptrToInt(test_file_path), test_file_path.len, @enumToInt(vfs.OpenFlags.CREATE_FILE), undefined, undefined));
+    var test_file = @intCast(task.Handle, try handleOpen(@ptrToInt(test_file_path), test_file_path.len, @enumToInt(vfs.OpenFlags.CREATE_FILE), 0, undefined));
     var f_data = &testfs.tree.children.items[0].data;
     var str = "test123";
     f_data.* = try testing.allocator.dupe(u8, str);
 
     var buffer: [str.len]u8 = undefined;
     {
-        const length = try handleRead(test_file, @ptrToInt(&buffer[0]), buffer.len, undefined, undefined);
+        const length = try handleRead(test_file, @ptrToInt(&buffer[0]), buffer.len, 0, undefined);
         try testing.expect(std.mem.eql(u8, str, buffer[0..length]));
     }
 
     {
-        const length = try handleRead(test_file, @ptrToInt(&buffer[0]), buffer.len + 1, undefined, undefined);
+        const length = try handleRead(test_file, @ptrToInt(&buffer[0]), buffer.len + 1, 0, undefined);
         try testing.expect(std.mem.eql(u8, str, buffer[0..length]));
     }
 
     {
-        const length = try handleRead(test_file, @ptrToInt(&buffer[0]), buffer.len + 3, undefined, undefined);
+        const length = try handleRead(test_file, @ptrToInt(&buffer[0]), buffer.len + 3, 0, undefined);
         try testing.expect(std.mem.eql(u8, str, buffer[0..length]));
     }
 
     {
-        const length = try handleRead(test_file, @ptrToInt(&buffer[0]), buffer.len - 1, undefined, undefined);
+        const length = try handleRead(test_file, @ptrToInt(&buffer[0]), buffer.len - 1, 0, undefined);
         try testing.expect(std.mem.eql(u8, str[0 .. str.len - 1], buffer[0..length]));
     }
 
     {
-        const length = try handleRead(test_file, @ptrToInt(&buffer[0]), 0, undefined, undefined);
+        const length = try handleRead(test_file, @ptrToInt(&buffer[0]), 0, 0, undefined);
         try testing.expect(std.mem.eql(u8, str[0..0], buffer[0..length]));
     }
     // Try reading from a symlink
     const args = vfs.OpenArgs{ .symlink_target = test_file_path };
     var test_link = @intCast(task.Handle, try handleOpen(@ptrToInt("/link"), "/link".len, @enumToInt(vfs.OpenFlags.CREATE_SYMLINK), @ptrToInt(&args), undefined));
     {
-        const length = try handleRead(test_link, @ptrToInt(&buffer[0]), buffer.len, undefined, undefined);
+        const length = try handleRead(test_link, @ptrToInt(&buffer[0]), buffer.len, 0, undefined);
         try testing.expect(std.mem.eql(u8, str[0..str.len], buffer[0..length]));
     }
 }

--- a/src/kernel/syscalls.zig
+++ b/src/kernel/syscalls.zig
@@ -416,7 +416,7 @@ test "getHandler" {
     try std.testing.expectEqual(Syscall.Write.getHandler(), handleWrite);
 }
 
-test "handle" {
+test "handle basic functionality" {
     try std.testing.expectEqual(@as(usize, 0), try handle(.Test1, 0, 0, 0, 0, 0));
     try std.testing.expectEqual(@as(usize, 1 + 2 + 3 + 4 + 5), try handle(.Test2, 1, 2, 3, 4, 5));
     try std.testing.expectError(Error.OutOfMemory, handle(.Test3, 0, 0, 0, 0, 0));

--- a/src/kernel/syscalls.zig
+++ b/src/kernel/syscalls.zig
@@ -16,28 +16,7 @@ var allocator: *std.mem.Allocator = undefined;
 pub const USER_MAX_DATA_LEN = 16 * 1024;
 
 /// A compilation of all errors that syscall handlers could return.
-pub const Error = error{
-    OutOfMemory,
-    NoMoreFSHandles,
-    InvalidFlags,
-    TooBig,
-    NoSuchFileOrDir,
-    NotADirectory,
-    IsADirectory,
-    IsAFile,
-    NotAFile,
-    NotAbsolutePath,
-    NotOpened,
-    NoSymlinkTarget,
-    OutOfBounds,
-    NotAllocated,
-    AlreadyAllocated,
-    PhysicalAlreadyAllocated,
-    PhysicalVirtualMismatch,
-    InvalidVirtAddresses,
-    InvalidPhysAddresses,
-    Unexpected,
-};
+pub const Error = error{ NoMoreFSHandles, TooBig, NotAFile } || std.mem.Allocator.Error || vfs.Error || vmm.VmmError || bitmap.Bitmap(usize).BitmapError;
 
 /// All implemented syscalls
 pub const Syscall = enum {

--- a/src/kernel/task.zig
+++ b/src/kernel/task.zig
@@ -23,6 +23,10 @@ extern var KERNEL_STACK_START: *u32;
 /// The number of vfs handles that a process can have. This is arbitrarily set to 65535
 pub const VFS_HANDLES_PER_PROCESS = std.math.maxInt(u16);
 
+comptime {
+    std.debug.assert(VFS_HANDLES_PER_PROCESS < std.math.maxInt(vfs.Handle));
+}
+
 /// The function type for the entry point.
 pub const EntryPoint = usize;
 

--- a/src/kernel/task.zig
+++ b/src/kernel/task.zig
@@ -196,7 +196,7 @@ pub const Task = struct {
 
     pub fn clearVFSHandle(self: *@This(), handle: Handle) (bitmap.Bitmap(usize).BitmapError || Error)!void {
         if (try self.hasVFSHandle(handle)) {
-            try self.file_handles.clearEntry(handle);
+            self.file_handles.clearEntry(handle) catch unreachable;
             _ = self.file_handle_mapping.remove(handle);
         } else {
             return Error.VFSHandleNotSet;

--- a/src/kernel/task.zig
+++ b/src/kernel/task.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const expectEqual = std.testing.expectEqual;
 const expectError = std.testing.expectError;
+const expect = std.testing.expect;
 const builtin = @import("builtin");
 const is_test = builtin.is_test;
 const build_options = @import("build_options");
@@ -21,11 +22,13 @@ const log = std.log.scoped(.task);
 extern var KERNEL_STACK_START: *u32;
 
 /// The number of vfs handles that a process can have. This is arbitrarily set to 65535
-pub const VFS_HANDLES_PER_PROCESS = std.math.maxInt(u16);
+pub const VFS_HANDLES_PER_PROCESS = 65535;
 
 comptime {
-    std.debug.assert(VFS_HANDLES_PER_PROCESS < std.math.maxInt(vfs.Handle));
+    std.debug.assert(VFS_HANDLES_PER_PROCESS < std.math.maxInt(Handle));
 }
+
+pub const Handle = usize;
 
 /// The function type for the entry point.
 pub const EntryPoint = usize;
@@ -71,7 +74,7 @@ pub const Task = struct {
     file_handles: bitmap.Bitmap(usize),
 
     /// The mapping between file handles and file nodes
-    file_handle_mapping: std.hash_map.AutoHashMap(vfs.Handle, *vfs.Node),
+    file_handle_mapping: std.hash_map.AutoHashMap(Handle, *vfs.Node),
 
     ///
     /// Create a task. This will allocate a PID and the stack. The stack will be set up as a
@@ -112,7 +115,7 @@ pub const Task = struct {
             .kernel = kernel,
             .vmm = task_vmm,
             .file_handles = try bitmap.Bitmap(usize).init(VFS_HANDLES_PER_PROCESS, allocator),
-            .file_handle_mapping = std.hash_map.AutoHashMap(vfs.Handle, *vfs.Node).init(allocator),
+            .file_handle_mapping = std.hash_map.AutoHashMap(Handle, *vfs.Node).init(allocator),
         };
 
         try arch.initTask(task, entry_point, allocator);
@@ -174,11 +177,8 @@ pub const Task = struct {
         allocator.destroy(self);
     }
 
-    pub fn getVFSHandle(self: @This(), handle: vfs.Handle) bitmap.Bitmap(usize).BitmapError!?*vfs.Node {
-        if (try self.hasVFSHandle(handle)) {
-            return self.file_handle_mapping.get(handle);
-        }
-        return null;
+    pub fn getVFSHandle(self: @This(), handle: Handle) bitmap.Bitmap(usize).BitmapError!?*vfs.Node {
+        return self.file_handle_mapping.get(handle);
     }
 
     pub fn hasFreeVFSHandle(self: @This()) bool {
@@ -195,11 +195,11 @@ pub const Task = struct {
         return null;
     }
 
-    pub fn hasVFSHandle(self: @This(), handle: vfs.Handle) bitmap.Bitmap(usize).BitmapError!bool {
+    pub fn hasVFSHandle(self: @This(), handle: Handle) bitmap.Bitmap(usize).BitmapError!bool {
         return self.file_handles.isSet(handle);
     }
 
-    pub fn clearVFSHandle(self: *@This(), handle: vfs.Handle) (bitmap.Bitmap(usize).BitmapError || Error)!void {
+    pub fn clearVFSHandle(self: *@This(), handle: Handle) (bitmap.Bitmap(usize).BitmapError || Error)!void {
         if (try self.hasVFSHandle(handle)) {
             try self.file_handles.clearEntry(handle);
             _ = self.file_handle_mapping.remove(handle);
@@ -426,17 +426,18 @@ test "hasFreeVFSHandle" {
     defer task.destroy(std.testing.allocator);
     var node1 = vfs.Node{ .Dir = .{ .fs = undefined, .mount = null } };
 
-    expectEqual(true, task.hasFreeVFSHandle());
+    expect(task.hasFreeVFSHandle());
 
     const handle1 = task.addVFSHandle(&node1) orelse unreachable;
-    expectEqual(true, task.hasFreeVFSHandle());
+    expect(task.hasFreeVFSHandle());
 
     var i: usize = 0;
     const free_entries = task.file_handles.num_free_entries;
     while (i < free_entries) : (i += 1) {
+        expect(task.hasFreeVFSHandle());
         _ = task.file_handles.setFirstFree();
     }
-    expectEqual(false, task.hasFreeVFSHandle());
+    expect(!task.hasFreeVFSHandle());
 }
 
 test "getVFSHandle" {

--- a/src/kernel/task.zig
+++ b/src/kernel/task.zig
@@ -406,14 +406,14 @@ test "addVFSHandle" {
     var node2 = vfs.Node{ .File = .{ .fs = undefined } };
 
     const handle1 = (try task.addVFSHandle(&node1)) orelse return error.FailedToAddVFSHandle;
-    expectEqual(handle1, 0);
-    expectEqual(&node1, task.file_handle_mapping.get(handle1).?);
-    expectEqual(true, try task.file_handles.isSet(handle1));
+    try expectEqual(handle1, 0);
+    try expectEqual(&node1, task.file_handle_mapping.get(handle1).?);
+    try expectEqual(true, try task.file_handles.isSet(handle1));
 
     const handle2 = (try task.addVFSHandle(&node2)) orelse return error.FailedToAddVFSHandle;
-    expectEqual(handle2, 1);
-    expectEqual(&node2, task.file_handle_mapping.get(handle2).?);
-    expectEqual(true, try task.file_handles.isSet(handle2));
+    try expectEqual(handle2, 1);
+    try expectEqual(&node2, task.file_handle_mapping.get(handle2).?);
+    try expectEqual(true, try task.file_handles.isSet(handle2));
 }
 
 test "hasFreeVFSHandle" {
@@ -421,18 +421,18 @@ test "hasFreeVFSHandle" {
     defer task.destroy(std.testing.allocator);
     var node1 = vfs.Node{ .Dir = .{ .fs = undefined, .mount = null } };
 
-    expect(task.hasFreeVFSHandle());
+    try expect(task.hasFreeVFSHandle());
 
-    const handle1 = (try task.addVFSHandle(&node1)) orelse return error.FailedToAddVFSHandle;
-    expect(task.hasFreeVFSHandle());
+    _ = (try task.addVFSHandle(&node1)) orelse return error.FailedToAddVFSHandle;
+    try expect(task.hasFreeVFSHandle());
 
     var i: usize = 0;
     const free_entries = task.file_handles.num_free_entries;
     while (i < free_entries) : (i += 1) {
-        expect(task.hasFreeVFSHandle());
+        try expect(task.hasFreeVFSHandle());
         _ = task.file_handles.setFirstFree();
     }
-    expect(!task.hasFreeVFSHandle());
+    try expect(!task.hasFreeVFSHandle());
 }
 
 test "getVFSHandle" {
@@ -442,13 +442,13 @@ test "getVFSHandle" {
     var node2 = vfs.Node{ .File = .{ .fs = undefined } };
 
     const handle1 = (try task.addVFSHandle(&node1)) orelse return error.FailedToAddVFSHandle;
-    expectEqual(&node1, (try task.getVFSHandle(handle1)).?);
+    try expectEqual(&node1, (try task.getVFSHandle(handle1)).?);
 
     const handle2 = (try task.addVFSHandle(&node2)) orelse return error.FailedToAddVFSHandle;
-    expectEqual(&node2, (try task.getVFSHandle(handle2)).?);
-    expectEqual(&node1, (try task.getVFSHandle(handle1)).?);
+    try expectEqual(&node2, (try task.getVFSHandle(handle2)).?);
+    try expectEqual(&node1, (try task.getVFSHandle(handle1)).?);
 
-    expectEqual(task.getVFSHandle(handle2 + 1), null);
+    try expectEqual(task.getVFSHandle(handle2 + 1), null);
 }
 
 test "clearVFSHandle" {
@@ -461,12 +461,12 @@ test "clearVFSHandle" {
     const handle2 = (try task.addVFSHandle(&node2)) orelse return error.FailedToAddVFSHandle;
 
     try task.clearVFSHandle(handle1);
-    expectEqual(false, try task.hasVFSHandle(handle1));
+    try expectEqual(false, try task.hasVFSHandle(handle1));
 
     try task.clearVFSHandle(handle2);
-    expectEqual(false, try task.hasVFSHandle(handle2));
+    try expectEqual(false, try task.hasVFSHandle(handle2));
 
-    expectError(Task.Error.VFSHandleNotSet, task.clearVFSHandle(handle2 + 1));
-    expectError(Task.Error.VFSHandleNotSet, task.clearVFSHandle(handle2));
-    expectError(Task.Error.VFSHandleNotSet, task.clearVFSHandle(handle1));
+    try expectError(Task.Error.VFSHandleNotSet, task.clearVFSHandle(handle2 + 1));
+    try expectError(Task.Error.VFSHandleNotSet, task.clearVFSHandle(handle2));
+    try expectError(Task.Error.VFSHandleNotSet, task.clearVFSHandle(handle1));
 }

--- a/src/kernel/task.zig
+++ b/src/kernel/task.zig
@@ -46,7 +46,11 @@ pub const STACK_SIZE: u32 = arch.MEMORY_BLOCK_SIZE / @sizeOf(u32);
 
 /// The task control block for storing all the information needed to save and restore a task.
 pub const Task = struct {
-    pub const Error = error{VFSHandleNotSet};
+    pub const Error = error{
+        /// The supplied vfs handle hasn't been allocated
+        VFSHandleNotSet,
+    };
+
     const Self = @This();
 
     /// The unique task identifier

--- a/src/kernel/task.zig
+++ b/src/kernel/task.zig
@@ -34,12 +34,7 @@ pub const EntryPoint = usize;
 const PidBitmap = if (is_test) ComptimeBitmap(u128) else ComptimeBitmap(u1024);
 
 /// The list of PIDs that have been allocated.
-var all_pids: PidBitmap = brk: {
-    var pids = PidBitmap.init();
-    // Set the first PID as this is for the current task running, init 0
-    _ = pids.setFirstFree() orelse unreachable;
-    break :brk pids;
-};
+var all_pids = PidBitmap.init();
 
 /// The default stack size of a task. Currently this is set to a page size.
 pub const STACK_SIZE: u32 = arch.MEMORY_BLOCK_SIZE / @sizeOf(u32);

--- a/src/kernel/task.zig
+++ b/src/kernel/task.zig
@@ -187,11 +187,10 @@ pub const Task = struct {
     }
 
     pub fn addVFSHandle(self: *@This(), node: *vfs.Node) std.mem.Allocator.Error!?Handle {
-        if (self.hasFreeVFSHandle()) {
-            // Cannot error as we've already checked that there is a free entry
-            const handle = @intCast(Handle, self.file_handles.setFirstFree() orelse unreachable);
-            try self.file_handle_mapping.put(handle, node);
-            return handle;
+        if (self.file_handles.setFirstFree()) |handle| {
+            const real_handle = @intCast(Handle, handle);
+            try self.file_handle_mapping.put(real_handle, node);
+            return real_handle;
         }
         return null;
     }

--- a/src/kernel/task.zig
+++ b/src/kernel/task.zig
@@ -405,12 +405,12 @@ test "addVFSHandle" {
     var node1 = vfs.Node{ .Dir = .{ .fs = undefined, .mount = null } };
     var node2 = vfs.Node{ .File = .{ .fs = undefined } };
 
-    const handle1 = (try task.addVFSHandle(&node1)) orelse unreachable;
+    const handle1 = (try task.addVFSHandle(&node1)) orelse panic(@errorReturnTrace(), "Failed to add a vfs handle\n", .{});
     expectEqual(handle1, 0);
     expectEqual(&node1, task.file_handle_mapping.get(handle1).?);
     expectEqual(true, try task.file_handles.isSet(handle1));
 
-    const handle2 = (try task.addVFSHandle(&node2)) orelse unreachable;
+    const handle2 = (try task.addVFSHandle(&node2)) orelse panic(@errorReturnTrace(), "Failed to add a vfs handle\n", .{});
     expectEqual(handle2, 1);
     expectEqual(&node2, task.file_handle_mapping.get(handle2).?);
     expectEqual(true, try task.file_handles.isSet(handle2));
@@ -423,7 +423,7 @@ test "hasFreeVFSHandle" {
 
     expect(task.hasFreeVFSHandle());
 
-    const handle1 = (try task.addVFSHandle(&node1)) orelse unreachable;
+    const handle1 = (try task.addVFSHandle(&node1)) orelse panic(@errorReturnTrace(), "Failed to add a vfs handle\n", .{});
     expect(task.hasFreeVFSHandle());
 
     var i: usize = 0;
@@ -441,10 +441,10 @@ test "getVFSHandle" {
     var node1 = vfs.Node{ .Dir = .{ .fs = undefined, .mount = null } };
     var node2 = vfs.Node{ .File = .{ .fs = undefined } };
 
-    const handle1 = (try task.addVFSHandle(&node1)) orelse unreachable;
+    const handle1 = (try task.addVFSHandle(&node1)) orelse panic(@errorReturnTrace(), "Failed to add a vfs handle\n", .{});
     expectEqual(&node1, (try task.getVFSHandle(handle1)).?);
 
-    const handle2 = (try task.addVFSHandle(&node2)) orelse unreachable;
+    const handle2 = (try task.addVFSHandle(&node2)) orelse panic(@errorReturnTrace(), "Failed to add a vfs handle\n", .{});
     expectEqual(&node2, (try task.getVFSHandle(handle2)).?);
     expectEqual(&node1, (try task.getVFSHandle(handle1)).?);
 
@@ -457,8 +457,8 @@ test "clearVFSHandle" {
     var node1 = vfs.Node{ .Dir = .{ .fs = undefined, .mount = null } };
     var node2 = vfs.Node{ .File = .{ .fs = undefined } };
 
-    const handle1 = (try task.addVFSHandle(&node1)) orelse unreachable;
-    const handle2 = (try task.addVFSHandle(&node2)) orelse unreachable;
+    const handle1 = (try task.addVFSHandle(&node1)) orelse panic(@errorReturnTrace(), "Failed to add a vfs handle\n", .{});
+    const handle2 = (try task.addVFSHandle(&node2)) orelse panic(@errorReturnTrace(), "Failed to add a vfs handle\n", .{});
 
     try task.clearVFSHandle(handle1);
     expectEqual(false, try task.hasVFSHandle(handle1));

--- a/src/kernel/vmm.zig
+++ b/src/kernel/vmm.zig
@@ -306,6 +306,9 @@ pub fn VirtualMemoryManager(comptime Payload: type) type {
         ///     Bitmap(u32).Error.OutOfBounds - The address given is outside of the memory managed
         ///
         pub fn isSet(self: *const Self, virt: usize) bitmap.BitmapError!bool {
+            if (virt < self.start) {
+                return bitmap.BitmapError.OutOfBounds;
+            }
             return self.bmp.isSet((virt - self.start) / BLOCK_SIZE);
         }
 
@@ -446,6 +449,7 @@ pub fn VirtualMemoryManager(comptime Payload: type) type {
             }
             const start_addr = std.mem.alignBackward(address, BLOCK_SIZE);
             const end_addr = std.mem.alignForward(address + data.len, BLOCK_SIZE);
+
             if (end_addr >= other.end or start_addr < other.start)
                 return bitmap.BitmapError.OutOfBounds;
             // Find physical blocks for the address


### PR DESCRIPTION
This patch adds the open, read, write and close VFS operations to the syscall interface.

* open(path_ptr, path_len, flags, args_ptr) handle
* close(handle) void
* read(handle, buff_ptr, buf_len) bytes_read
* write(handle, buff_ptr, buff_len) bytes_written

It also adds a handle -> vfs node mapping for each task to keep track of what a handle corresponds to for that task.

Closes #265 
