### PR TITLE
Use install_path everywhere

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     name: Build mode ${{ matrix.build_mode }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         build_mode: ["", -Drelease-fast, -Drelease-safe, -Drelease-small]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     name: Build mode ${{ matrix.build_mode }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         build_mode: ["", -Drelease-fast, -Drelease-safe, -Drelease-small]


### PR DESCRIPTION
Some parts of the build.zig code use `b.cache_root` ﻿whereas the executable build step uses `b.cache_root` so when the two are different, `b.install_path` won't exist because only `b.cache_root` will be created. This also means we can try going back to the latest ubuntu version.
