### PR TITLE
Lock zig master version to ad33e3483

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,8 @@ jobs:
     - name: Download zig
       run: |
         export PYTHONIOENCODING=utf8
-        wget $(curl -s 'https://ziglang.org/download/index.json' | python3 -c "import sys, json; print(json.load(sys.stdin)['master']['x86_64-linux']['tarball'])")
+        # Lock the master commit that we download, because of blocking issues
+        wget https://ziglang.org/builds/zig-linux-x86_64-0.8.0-dev.2133+ad33e3483.tar.xz
         sudo apt-get install mtools
         tar -xvf zig*
     - name: Install qemu

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ All of these goals will benefit from the features of Zig.
 
 ## Build
 
-Requires a master build of Zig ([downloaded](https://ziglang.org/download) or [built from source](https://github.com/ziglang/zig#building-from-source)) *xorriso* and the grub tools (such as *grub-mkrescue*). A *qemu-system* binary compatible with your chosen target is required to run the kernel (e.g. *qemu-system-i386*).
+Requires a master build of Zig at commit ad33e3483 ([downloaded](https://ziglang.org/builds/zig-linux-x86_64-0.8.0-dev.2133+ad33e3483.tar.xz) or [built from source](https://github.com/ziglang/zig#building-from-source)), *xorriso* and the grub tools (such as *grub-mkrescue*). A *qemu-system* binary compatible with your chosen target is required to run the kernel (e.g. *qemu-system-i386*).
 
 ```Shell
 zig build


### PR DESCRIPTION
`std.testing.expectEqual` has stopped working for the IdtEntry struct as of https://github.com/ziglang/zig/commit/59f9253d94331cedd4d0518250c8094a064f6cd2 . This PR locks the version of zig we use in CI so we don't have to wait for the issue to be fixed before continuing to work on pluto.﻿
