### PR TITLE
Add directory listing

### DIFF
--- a/src/kernel/filesystem/vfs.zig
+++ b/src/kernel/filesystem/vfs.zig
@@ -178,7 +178,7 @@ pub const FileSystem = struct {
 
     deinitDirIterator: fn (dir: *const DirNode) void,
 
-    listDirIterator: fn (dir: *const DirNode, i: usize) ?*const Node,
+    listDirIterator: fn (dir: *const DirNode, i: usize) ?[]const u8,
 
     /// Points to a usize field within the underlying filesystem so that the close, read, write and open functions can access its low-level implementation using @fieldParentPtr. For example, this could point to a usize field within a FAT32 filesystem data structure, which stores all the data and state that is needed in order to interact with a physical disk
     /// The value of instance is reserved for future use and so should be left as 0
@@ -226,7 +226,7 @@ pub const DirNode = struct {
             return DirIterator{ .dir = node, .i = 0 };
         }
 
-        pub fn next(self: *Self) ?*const Node {
+        pub fn next(self: *Self) ?[]const u8 {
             self.i += 1;
             return self.dir.fs.listDirIterator(dir, self.i - 1);
         }
@@ -761,11 +761,11 @@ const TestFS = struct {
         test_fs.allocator.free(test_fs.dir_iter_dummy_memory.get(node) orelse unreachable);
     }
 
-    pub fn listDirIterator(node: *const DirNode, i: usize) ?*const Node {
+    pub fn listDirIterator(node: *const DirNode, i: usize) ?[]const u8 {
         var test_fs = @fieldParentPtr(TestFS, "instance", node.fs.instance);
         const tree_node = (try getTreeNode(test_fs, node)) orelse unreachable;
         if (tree_node.children.items.len <= i) return null;
-        return tree_node.children.items[i].val;
+        return tree_node.children.items[i].name;
     }
 };
 

--- a/src/kernel/filesystem/vfs.zig
+++ b/src/kernel/filesystem/vfs.zig
@@ -1070,17 +1070,33 @@ test "list" {
     defer testfs.deinit();
     root = testfs.tree.val;
 
-    const child_1 = try openFile("/child1.txt", .CREATE_FILE);
-    const child_2 = try openFile("/child2.txt", .CREATE_FILE);
-    const child_3 = try openDir("/child3", .CREATE_DIR);
+    const child_1_name = "child1.txt";
+    const child_2_name = "child2.txt";
+    const child_3_name = "child3";
+    const child_3_1_name = "child3_1.txt";
+    const child_3_2_name = "child3_2.txt";
+
+    const child_1 = try openFile("/" ++ child_1_name, .CREATE_FILE);
+    const child_2 = try openFile("/" ++ child_2_name, .CREATE_FILE);
+    const child_3 = try openDir("/" ++ child_3_name, .CREATE_DIR);
 
     var iterator = root.Dir.list();
     defer iterator.deinit();
-    testing.expectEqual(child_1, iterator.next());
-    testing.expectEqual(child_2, iterator.next());
-    testing.expectEqual(null, iterator.next());
+    testing.expectEqualSlices(child_1_name, iterator.next());
+    testing.expectEqualSlices(child_2_name, iterator.next());
+    testing.expectEqualSlices(child_3_name, iterator.next());
+    testing.expectEqualSlices(null, iterator.next());
 
     var iterator2 = child_3.list();
     defer iterator2.deinit();
-    testing.expectEqual(null, iterator2.next());
+    testing.expectEqualSlices(null, iterator2.next());
+
+    const child_3_1 = try openDir("/" ++ child_3_name ++ "/" ++ child_3_1_name, .CREATE_DIR);
+    testing.expectEqualSlices(child_3_1_name, iterator2.next());
+    testing.expectEqualSlices(null, iterator2.next());
+
+    const child_3_2 = try openDir("/" ++ child_3_name ++ "/" ++ child_3_2_name, .CREATE_DIR);
+    testing.expectEqualSlices(child_3_1_name, iterator2.next());
+    testing.expectEqualSlices(child_3_2_name, iterator2.next());
+    testing.expectEqualSlices(null, iterator2.next());
 }


### PR DESCRIPTION
This PR adds the ability to list the children of directories. It does so with an iterator and delegates the iteration logic to the filesystem itself as it is implementation-dependent. Closes #196﻿
