### PR TITLE
Run CI in docker container

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,7 @@ jobs:
   test:
     name: Build mode ${{ matrix.build_mode }}
     runs-on: ubuntu-18.04
+    container: samtebbs33/zig-ad33e3483
     strategy:
       matrix:
         build_mode: ["", -Drelease-fast, -Drelease-safe, -Drelease-small]
@@ -16,26 +17,18 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     
-    - name: Download zig
+    - name: Download mtools
       run: |
-        export PYTHONIOENCODING=utf8
-        # Lock the master commit that we download, because of blocking issues
-        wget https://ziglang.org/builds/zig-linux-x86_64-0.8.0-dev.2133+ad33e3483.tar.xz
         sudo apt-get install mtools
-        tar -xvf zig*
-    - name: Install qemu
-      run: |
-        sudo apt-get update
-        sudo apt-get install qemu qemu-system --fix-missing
     - name: Check formatting
-      run: zig*/zig fmt --check src
+      run: zig fmt --check src
     - name: Build kernel
-      run: zig*/zig build ${{ matrix.build_mode }}
+      run: zig build ${{ matrix.build_mode }}
     - name: Run unit tests
-      run: zig*/zig build test ${{ matrix.build_mode }}
+      run: zig build test ${{ matrix.build_mode }}
     - name: Run runtime test - Initialisation
-      run: zig*/zig build rt-test -Ddisable-display -Dtest-mode=Initialisation ${{ matrix.build_mode }}
+      run: zig build rt-test -Ddisable-display -Dtest-mode=Initialisation ${{ matrix.build_mode }}
     - name: Run runtime test - Panic
-      run: zig*/zig build rt-test -Ddisable-display -Dtest-mode=Panic ${{ matrix.build_mode }}
+      run: zig build rt-test -Ddisable-display -Dtest-mode=Panic ${{ matrix.build_mode }}
     - name: Run runtime test - Scheduler
-      run: zig*/zig build rt-test -Ddisable-display -Dtest-mode=Scheduler ${{ matrix.build_mode }}
+      run: zig build rt-test -Ddisable-display -Dtest-mode=Scheduler ${{ matrix.build_mode }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,8 @@ jobs:
     
     - name: Download mtools
       run: |
-        sudo apt-get install mtools
+        apt-get update
+        apt-get install mtools
     - name: Check formatting
       run: zig fmt --check src
     - name: Build kernel


### PR DESCRIPTION
This PR runs the CI in a docker container that has llvm 12 and zig ad33e3483 installed. The intention behind this is to get CI passing on a working version of zig master so we don't have to wait for #310﻿
