### PR TITLE
Pass cpu state to syscall handler

### DIFF
--- a/src/kernel/arch/x86/arch.zig
+++ b/src/kernel/arch/x86/arch.zig
@@ -87,6 +87,31 @@ pub const CpuState = packed struct {
     eflags: u32,
     user_esp: u32,
     user_ss: u32,
+
+    pub fn empty() CpuState {
+        return .{
+            .cr3 = undefined,
+            .gs = undefined,
+            .fs = undefined,
+            .es = undefined,
+            .ds = undefined,
+            .edi = undefined,
+            .esi = undefined,
+            .ebp = undefined,
+            .esp = undefined,
+            .ebx = undefined,
+            .edx = undefined,
+            .ecx = undefined,
+            .eax = undefined,
+            .int_num = undefined,
+            .error_code = undefined,
+            .eip = undefined,
+            .cs = undefined,
+            .eflags = undefined,
+            .user_esp = undefined,
+            .user_ss = undefined,
+        };
+    }
 };
 
 /// x86's boot payload is the multiboot info passed by grub

--- a/test/mock/kernel/arch_mock.zig
+++ b/test/mock/kernel/arch_mock.zig
@@ -54,6 +54,31 @@ pub const CpuState = struct {
     eflags: u32,
     user_esp: u32,
     user_ss: u32,
+
+    pub fn empty() CpuState {
+        return .{
+            .ss = undefined,
+            .gs = undefined,
+            .fs = undefined,
+            .es = undefined,
+            .ds = undefined,
+            .edi = undefined,
+            .esi = undefined,
+            .ebp = undefined,
+            .esp = undefined,
+            .ebx = undefined,
+            .edx = undefined,
+            .ecx = undefined,
+            .eax = undefined,
+            .int_num = undefined,
+            .error_code = undefined,
+            .eip = undefined,
+            .cs = undefined,
+            .eflags = undefined,
+            .user_esp = undefined,
+            .user_ss = undefined,
+        };
+    }
 };
 
 pub const VmmPayload = switch (builtin.cpu.arch) {


### PR DESCRIPTION
Some syscalls (such as exit) will need to have the CPU state available (e.g. to know the stack pointer). This PR passes the CPU state from the arch syscall handler to the arch-independent syscall handler.