### PR TITLE
Ignore zig-out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Zig ignore
 **/zig-cache/
+**/zig-out/
 **/build/
 **/build-*/
 **/docgen_tmp/


### PR DESCRIPTION
Ignores the zig-out directory, which is the new standard directory for zig output.